### PR TITLE
Added Toggle Find My Friends

### DIFF
--- a/gui/main_window.py
+++ b/gui/main_window.py
@@ -98,6 +98,7 @@ class MainWindow(QtWidgets.QMainWindow):
         self.ui.stageManagerChk.clicked.connect(self.on_stageManagerChk_clicked)
         self.ui.ipadAppsChk.clicked.connect(self.on_ipadAppsChk_clicked)
         self.ui.shutterChk.clicked.connect(self.on_shutterChk_clicked)
+        self.ui.findMyFriendsChk.clicked.connect(self.on_findMyFriendsChk_clicked)
         self.ui.pencilChk.clicked.connect(self.on_pencilChk_clicked)
         self.ui.actionButtonChk.clicked.connect(self.on_actionButtonChk_clicked)
 
@@ -318,6 +319,8 @@ class MainWindow(QtWidgets.QMainWindow):
     def on_shutterChk_clicked(self, checked: bool):
         # TODO: allow the user to select the region
         tweaks["Shutter"].set_enabled(checked)
+    def on_findMyFriendsChk_clicked(self, checked: bool):
+        tweaks["FindMyFriends"].set_enabled(checked)
     def on_pencilChk_clicked(self, checked: bool):
         tweaks["Pencil"].set_enabled(checked)
     def on_actionButtonChk_clicked(self, checked: bool):

--- a/qt/ui_mainwindow.py
+++ b/qt/ui_mainwindow.py
@@ -1417,6 +1417,11 @@ class Ui_Nugget(object):
 
         self.verticalLayout_8.addWidget(self.shutterChk)
 
+        self.findMyFriendsChk = QCheckBox(self.gestaltPageContent)
+        self.findMyFriendsChk.setObjectName(u"findMyFriendsChk")
+
+        self.verticalLayout_8.addWidget(self.findMyFriendsChk)
+
         self.pencilChk = QCheckBox(self.gestaltPageContent)
         self.pencilChk.setObjectName(u"pencilChk")
 
@@ -2192,6 +2197,7 @@ class Ui_Nugget(object):
         self.stageManagerChk.setText(QCoreApplication.translate("Nugget", u"Enable Stage Manager Supported (WARNING: risky on some devices, mainly phones)", None))
         self.ipadAppsChk.setText(QCoreApplication.translate("Nugget", u"Allow iPad Apps on iPhone", None))
         self.shutterChk.setText(QCoreApplication.translate("Nugget", u"Disable Region Restrictions (ie. Shutter Sound)", None))
+        self.findMyFriendsChk.setText(QCoreApplication.translate("Nugget", u"Enable Find My Friends", None))
         self.pencilChk.setText(QCoreApplication.translate("Nugget", u"Enable Apple Pencil Settings Tab", None))
         self.actionButtonChk.setText(QCoreApplication.translate("Nugget", u"Enable Action Button Settings Tab", None))
         self.internalInstallChk.setText(QCoreApplication.translate("Nugget", u"Set as Apple Internal Install (ie Metal HUD in any app)", None))

--- a/tweaks/tweaks.py
+++ b/tweaks/tweaks.py
@@ -17,6 +17,7 @@ tweaks = {
     "StageManager": MobileGestaltTweak("Toggle Stage Manager Supported (WARNING: risky on some devices, mainly phones)", "qeaj75wk3HF4DwQ8qbIi7g", value=1),
     "iPadApps": MobileGestaltTweak("Allow iPad Apps on iPhone", "9MZ5AdH43csAUajl/dU+IQ", value=[1, 2]),
     "Shutter": MobileGestaltMultiTweak("Disable Region Restrictions (ie. Shutter Sound)", {"h63QSdBCiT/z0WU6rdQv6Q": "US", "zHeENZu+wbg7PUprwNwBWg": "LL/A"}),
+    "FindMyFriends": MobileGestaltTweak("Toggle Find My Friends", "Y2Y67z0Nq/XdDXgW2EeaVg"),
     "Pencil": MobileGestaltTweak("Toggle Apple Pencil", "yhHcB0iH0d1XzPO/CFd3ow"),
     "ActionButton": MobileGestaltTweak("Toggle Action Button", "cT44WE1EohiwRzhsZ8xEsw"),
     "InternalStorage": MobileGestaltTweak("Toggle Internal Storage (WARNING: risky for some devices, mainly iPads)", "LBJfwOEzExRxzlAnSuI7eg"),


### PR DESCRIPTION
#### Tested on devices:
- iPhone X (NQAG2KH/A) (iOS 16.7.9)
- iPhone 14 Pro Max (MQ9V3KH/A) (iOS 18.0)

#### Changes:
- Toggle to activate Find My Friends on an iPhone that does not officially supports it due to region restrictions (Korea, Republic of / Suffix: KH).

#### Screenshot:
<img src="https://github.com/user-attachments/assets/c1d0d720-d8d1-4d93-b852-1340fd0e7602" width="200" />

#### References:
- [The Apple Wiki - List of MobileGestalt keys](https://theapplewiki.com/wiki/List_of_MobileGestalt_keys) - FMFAllowed