### PR TITLE
Use GitHub actions to build Nugget & Intel support for MacOS

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,99 @@
+name: Build Nugget
+
+on:
+  workflow_dispatch:
+    inputs:
+      release_version:
+        description: 'Which version is this release?'
+        required: true
+
+jobs:
+  build-macos-intel:
+    runs-on: macos-13
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.11'
+
+      - name: Install dependencies
+        run: |
+          python3 -m pip install --upgrade pip
+          pip install -r requirements.txt
+
+      - name: Build MacOS (Intel)
+        run: python3 compile.py
+
+      - name: Zip Nugget.app (Intel)
+        run: |
+          cd dist
+          zip -r "Nugget_macOS_intel.zip" Nugget.app
+
+  build-macos-arm:
+    runs-on: macos-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.11'
+
+      - name: Install dependencies
+        run: |
+          python3 -m pip install --upgrade pip
+          pip install -r requirements.txt
+
+      - name: Build MacOS (ARM)
+        run: python3 compile.py
+
+      - name: Zip Nugget.app (ARM)
+        run: |
+          cd dist
+          zip -r "Nugget_macOS_arm.zip" Nugget.app
+
+  build-windows:
+    runs-on: windows-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.11'
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+
+      - name: Build Windows
+        run: python compile.py
+
+      - name: Zip Nugget
+        run: |
+          cd dist
+          Compress-Archive -Path Nugget -DestinationPath "Nugget_Windows.zip"
+
+  create-release:
+    runs-on: ubuntu-latest
+    needs: [build-macos-intel, build-macos-arm, build-windows]
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+
+      - name: Create Release
+        uses: marvinpinto/action-automatic-releases@latest
+        with:
+          repo_token: "${{ secrets.GITHUB_TOKEN }}"
+          prerelease: false
+          automatic_release_tag: ${{ github.event.inputs.release_version }}
+          files: |
+            dist/Nugget_macOS_intel.zip
+            dist/Nugget_macOS_arm.zip
+            dist/Nugget_Windows.zip

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -33,7 +33,7 @@ jobs:
           zip -r "Nugget_macOS_intel.zip" Nugget.app
 
       - name: Upload ZIP (Intel)
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: Nugget_macOS_intel
           path: dist/Nugget_macOS_intel.zip
@@ -63,7 +63,7 @@ jobs:
           zip -r "Nugget_macOS_arm.zip" Nugget.app
 
       - name: Upload ZIP (ARM)
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: Nugget_macOS_arm
           path: dist/Nugget_macOS_arm.zip
@@ -93,7 +93,7 @@ jobs:
           Compress-Archive -Path Nugget -DestinationPath "Nugget_Windows.zip"
 
       - name: Upload ZIP (Windows)
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: Nugget_Windows
           path: dist/Nugget_Windows.zip
@@ -103,17 +103,17 @@ jobs:
     needs: [build-macos-intel, build-macos-arm, build-windows]
     steps:
       - name: Download ZIP (Intel)
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v4
         with:
           name: Nugget_macOS_intel
 
       - name: Download ZIP (ARM)
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v4
         with:
           name: Nugget_macOS_arm
 
       - name: Download ZIP (Windows)
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v4
         with:
           name: Nugget_Windows
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -32,6 +32,12 @@ jobs:
           cd dist
           zip -r "Nugget_macOS_intel.zip" Nugget.app
 
+      - name: Upload ZIP (Intel)
+        uses: actions/upload-artifact@v2
+        with:
+          name: Nugget_macOS_intel
+          path: dist/Nugget_macOS_intel.zip
+
   build-macos-arm:
     runs-on: macos-latest
     steps:
@@ -55,6 +61,12 @@ jobs:
         run: |
           cd dist
           zip -r "Nugget_macOS_arm.zip" Nugget.app
+
+      - name: Upload ZIP (ARM)
+        uses: actions/upload-artifact@v2
+        with:
+          name: Nugget_macOS_arm
+          path: dist/Nugget_macOS_arm.zip
 
   build-windows:
     runs-on: windows-latest
@@ -80,12 +92,30 @@ jobs:
           cd dist
           Compress-Archive -Path Nugget -DestinationPath "Nugget_Windows.zip"
 
+      - name: Upload ZIP (Windows)
+        uses: actions/upload-artifact@v2
+        with:
+          name: Nugget_Windows
+          path: dist/Nugget_Windows.zip
+
   create-release:
     runs-on: ubuntu-latest
     needs: [build-macos-intel, build-macos-arm, build-windows]
     steps:
-      - name: Checkout code
-        uses: actions/checkout@v3
+      - name: Download ZIP (Intel)
+        uses: actions/download-artifact@v2
+        with:
+          name: Nugget_macOS_intel
+
+      - name: Download ZIP (ARM)
+        uses: actions/download-artifact@v2
+        with:
+          name: Nugget_macOS_arm
+
+      - name: Download ZIP (Windows)
+        uses: actions/download-artifact@v2
+        with:
+          name: Nugget_Windows
 
       - name: Create Release
         uses: marvinpinto/action-automatic-releases@latest
@@ -94,6 +124,6 @@ jobs:
           prerelease: false
           automatic_release_tag: ${{ github.event.inputs.release_version }}
           files: |
-            dist/Nugget_macOS_intel.zip
-            dist/Nugget_macOS_arm.zip
-            dist/Nugget_Windows.zip
+            Nugget_macOS_intel.zip
+            Nugget_macOS_arm.zip
+            Nugget_Windows.zip

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 pymobiledevice3
 pyside6
+PyInstaller


### PR DESCRIPTION
The title says all

The change in requirements.txt is needed for the GitHub Workflow and it would not compile if you ran compile.py and used `pip install -r requirements.txt`.