### PR TITLE
Fix nested quotes in fstring for python > 3.12 stopping launch

### DIFF
--- a/tweaks/posterboard/template_file.py
+++ b/tweaks/posterboard/template_file.py
@@ -289,7 +289,7 @@ class TemplateFile(TendieFile):
             bx_lbl.setText("App bundle id:")
             bx_layout.addWidget(bx_lbl)
             textbox = QtWidgets.QLineEdit(bx_widget)
-            textbox.setPlaceholderText(f"Bundle id (default: {self.domain.removeprefix("AppDomain-")})")
+            textbox.setPlaceholderText(f"Bundle id (default: {self.domain.removeprefix('AppDomain-')})")
             textbox.setText(self.bundle_id)
             textbox.textEdited.connect(self.update_bundle_id)
             bx_layout.addWidget(textbox)

--- a/tweaks/posterboard/template_options/templates_tweak.py
+++ b/tweaks/posterboard/template_options/templates_tweak.py
@@ -63,7 +63,7 @@ class TemplatesTweak(Tweak):
                         full_path = f"{restore_path}/{folder}"
                         restore_domain = domain
                         if domain.startswith("Sparserestore-"):
-                            full_path = f"{domain.removeprefix("Sparserestore-")}{full_path}"
+                            full_path = f"{domain.removeprefix('Sparserestore-')}{full_path}"
                             restore_domain = None
                         full_path = self.parse_path_string(full_path, old_bundle, domain)
                         files_to_restore.append(FileToRestore(


### PR DESCRIPTION
* [`tweaks/posterboard/template_file.py`](diffhunk://#diff-d34db5d14b21a353357b00e5ff2603b414590bc151e860b9717c1c72e41c5629L292-R292): Updated the placeholder text for the `textbox` widget to use single quotes instead of double quotes in the `removeprefix` method call.
* [`tweaks/posterboard/template_options/templates_tweak.py`](diffhunk://#diff-c6225bbb9c359ddac9ce6b59e736e46381e8f6a1f43c4ce1d8b9f629ca818e3bL66-R66): Changed the `removeprefix` method call to use single quotes instead of double quotes when modifying the `full_path` variable.

Prior to python 3.12, strings with the same quotation delimiter as the f string that they are nested in are invalid syntax. This prevents successful execution and pyinstaller won't even include those files when below python 3.12.

Since the project states python 3.8 as the minimum required python, this should be fixed to maintain compatibility within the intended version range.