### PR TITLE
Add Auto-Lock (Lock Screen) slider to set SBMinimumLockscreenIdleTime

### DIFF
--- a/gui/pages/tools/springboard.py
+++ b/gui/pages/tools/springboard.py
@@ -38,3 +38,5 @@ class SpringboardPage(Page):
         tweaks["AirplaySupport"].set_enabled(checked)
     def on_hideACPowerChk_clicked(self, checked: bool):
         tweaks["SBHideACPower"].set_enabled(checked)
+    def on_lockScreenAutoLockSlider_valueChanged(self, value: int):
+        tweaks["SBMinimumLockscreenIdleTime"].set_value(value, toggle_enabled=True)

--- a/gui/pages/tools/springboard.py
+++ b/gui/pages/tools/springboard.py
@@ -18,6 +18,7 @@ class SpringboardPage(Page):
         self.ui.disableCrumbChk.toggled.connect(self.on_disableCrumbChk_clicked)
         self.ui.enableSupervisionTextChk.toggled.connect(self.on_enableSupervisionTextChk_clicked)
         self.ui.enableAirPlayChk.toggled.connect(self.on_enableAirPlayChk_clicked)
+        self.ui.lockScreenAutoLockSlider.valueChanged.connect(self.on_lockScreenAutoLockSlider_valueChanged)
         
         load_springboard()
 

--- a/mainwindow_ui.py
+++ b/mainwindow_ui.py
@@ -1741,15 +1741,34 @@ class Ui_Nugget(object):
 
         self._2.addWidget(self.footnoteTxt)
 
-        self.line_6 = QFrame(self.springboardOptionsPageContent)
-        self.line_6.setObjectName(u"line_6")
-        self.line_6.setStyleSheet(u"QFrame {\n"
+        self.lockScreenAutoLockLabel = QLabel(self.springboardOptionsPageContent)
+        self.lockScreenAutoLockLabel.setObjectName(u"lockScreenAutoLockLabel")
+
+        self._2.addWidget(self.lockScreenAutoLockLabel)
+
+        self.lockScreenAutoLockSlider = QSlider(self.springboardOptionsPageContent)
+        self.lockScreenAutoLockSlider.setObjectName(u"lockScreenAutoLockSlider")
+        self.lockScreenAutoLockSlider.setOrientation(Qt.Horizontal)
+        self.lockScreenAutoLockSlider.setRange(5, 100)
+        self.lockScreenAutoLockSlider.setValue(5)
+        self._2.addWidget(self.lockScreenAutoLockSlider)
+
+        self.lockScreenAutoLockValueLabel = QLabel(f"{self.lockScreenAutoLockSlider.value()} Seconds", self.springboardOptionsPageContent)
+        self._2.addWidget(self.lockScreenAutoLockValueLabel)
+
+        self.lockScreenAutoLockSlider.valueChanged.connect(
+            lambda v: self.lockScreenAutoLockValueLabel.setText(f"{v} {QCoreApplication.translate('Nugget', u'Seconds', None)}")
+        )
+
+        self.lockScreenAutoLockSeparator = QFrame(self.springboardOptionsPageContent)
+        self.lockScreenAutoLockSeparator.setObjectName(u"lockScreenAutoLockSeparator")
+        self.lockScreenAutoLockSeparator.setStyleSheet(u"QFrame {\n"
 "	color: #414141;\n"
 "}")
-        self.line_6.setFrameShadow(QFrame.Plain)
-        self.line_6.setFrameShape(QFrame.Shape.HLine)
+        self.lockScreenAutoLockSeparator.setFrameShadow(QFrame.Plain)
+        self.lockScreenAutoLockSeparator.setFrameShape(QFrame.Shape.HLine)
 
-        self._2.addWidget(self.line_6)
+        self._2.addWidget(self.lockScreenAutoLockSeparator)
 
         self.disableLockRespringChk = QCheckBox(self.springboardOptionsPageContent)
         self.disableLockRespringChk.setObjectName(u"disableLockRespringChk")
@@ -3697,6 +3716,7 @@ class Ui_Nugget(object):
         self.disableDimmingChk.setText(QCoreApplication.translate("Nugget", u"Disable Screen Dimming While Charging", None))
         self.disableBatteryAlertsChk.setText(QCoreApplication.translate("Nugget", u"Disable Low Battery Alerts", None))
         self.hideACPowerChk.setText(QCoreApplication.translate("Nugget", u"Hide AC Power on Lock Screen", None))
+        self.lockScreenAutoLockLabel.setText(QCoreApplication.translate("Nugget", u"Auto‑Lock (Lock Screen)", None))
 #if QT_CONFIG(tooltip)
         self.disableCrumbChk.setToolTip(QCoreApplication.translate("Nugget", u"Removes '< PreviousAppName' glyph in Status Bar when being forwarded to another app.", None))
 #endif // QT_CONFIG(tooltip)

--- a/qt/mainwindow.ui
+++ b/qt/mainwindow.ui
@@ -5350,6 +5350,22 @@ QComboBox QAbstractItemView::item:hover {
                   </widget>
                  </item>
                  <item>
+                 <item>
+                  <widget class="QSlider" name="lockScreenAutoLockSlider">
+                    <property name="orientation">
+                      <enum>Qt::Horizontal</enum>
+                     </property>
+                     <property name="minimum">
+                      <number>5</number>
+                     </property>
+                     <property name="maximum">
+                      <number>100</number>
+                     </property>
+                     <property name="value">
+                      <number>5</number>
+                     </property>
+                  </widget>
+                 </item>
                   <widget class="QCheckBox" name="disableCrumbChk">
                    <property name="toolTip">
                     <string>Removes '&lt; PreviousAppName' glyph in Status Bar when being forwarded to another app.</string>

--- a/qt/mainwindow_ui.py
+++ b/qt/mainwindow_ui.py
@@ -2807,6 +2807,35 @@ class Ui_Nugget(object):
 
         self._2.addWidget(self.footnoteLine)
 
+        self.lockScreenAutoLockLabel = QLabel(self.springboardOptionsPageContent)
+        self.lockScreenAutoLockLabel.setObjectName(u"lockScreenAutoLockLabel")
+
+        self._2.addWidget(self.lockScreenAutoLockLabel)
+
+        self.lockScreenAutoLockSlider = QSlider(self.springboardOptionsPageContent)
+        self.lockScreenAutoLockSlider.setObjectName(u"lockScreenAutoLockSlider")
+        self.lockScreenAutoLockSlider.setOrientation(Qt.Horizontal)
+        self.lockScreenAutoLockSlider.setRange(5, 100)
+        self.lockScreenAutoLockSlider.setValue(5)
+        self._2.addWidget(self.lockScreenAutoLockSlider)
+
+        self.lockScreenAutoLockValueLabel = QLabel(f"{self.lockScreenAutoLockSlider.value()} Seconds", self.springboardOptionsPageContent)
+        self._2.addWidget(self.lockScreenAutoLockValueLabel)
+
+        self.lockScreenAutoLockSlider.valueChanged.connect(
+            lambda v: self.lockScreenAutoLockValueLabel.setText(f"{v} {QCoreApplication.translate('Nugget', u'Seconds', None)}")
+        )
+
+        self.lockScreenAutoLockSeparator = QFrame(self.springboardOptionsPageContent)
+        self.lockScreenAutoLockSeparator.setObjectName(u"lockScreenAutoLockSeparator")
+        self.lockScreenAutoLockSeparator.setStyleSheet(u"QFrame {\n"
+"	color: #414141;\n"
+"}")
+        self.lockScreenAutoLockSeparator.setFrameShadow(QFrame.Plain)
+        self.lockScreenAutoLockSeparator.setFrameShape(QFrame.Shape.HLine)
+
+        self._2.addWidget(self.lockScreenAutoLockSeparator)
+
         self.disableLockRespringChk = QCheckBox(self.springboardOptionsPageContent)
         self.disableLockRespringChk.setObjectName(u"disableLockRespringChk")
 
@@ -4763,6 +4792,7 @@ class Ui_Nugget(object):
         self.disableDimmingChk.setText(QCoreApplication.translate("Nugget", u"Disable Screen Dimming While Charging", None))
         self.disableBatteryAlertsChk.setText(QCoreApplication.translate("Nugget", u"Disable Low Battery Alerts", None))
         self.hideACPowerChk.setText(QCoreApplication.translate("Nugget", u"Hide AC Power on Lock Screen", None))
+        self.lockScreenAutoLockLabel.setText(QCoreApplication.translate("Nugget", u"Auto‑Lock (Lock Screen)", None))
 #if QT_CONFIG(tooltip)
         self.disableCrumbChk.setToolTip(QCoreApplication.translate("Nugget", u"Removes '< PreviousAppName' glyph in Status Bar when being forwarded to another app.", None))
 #endif // QT_CONFIG(tooltip)

--- a/qt/ui_mainwindow.py
+++ b/qt/ui_mainwindow.py
@@ -2807,6 +2807,35 @@ class Ui_Nugget(object):
 
         self._2.addWidget(self.footnoteLine)
 
+
+        self.lockScreenAutoLockLabel = QLabel(self.springboardOptionsPageContent)
+        self.lockScreenAutoLockLabel.setObjectName(u"lockScreenAutoLockLabel")
+
+        self._2.addWidget(self.lockScreenAutoLockLabel)
+        self.lockScreenAutoLockSlider = QSlider(self.springboardOptionsPageContent)
+        self.lockScreenAutoLockSlider.setObjectName(u"lockScreenAutoLockSlider")
+        self.lockScreenAutoLockSlider.setOrientation(Qt.Horizontal)
+        self.lockScreenAutoLockSlider.setRange(5, 100)
+        self.lockScreenAutoLockSlider.setValue(5)
+        self._2.addWidget(self.lockScreenAutoLockSlider)
+
+        self.lockScreenAutoLockValueLabel = QLabel(f"{self.lockScreenAutoLockSlider.value()} Seconds", self.springboardOptionsPageContent)
+        self._2.addWidget(self.lockScreenAutoLockValueLabel)
+
+        self.lockScreenAutoLockSlider.valueChanged.connect(
+            lambda v: self.lockScreenAutoLockValueLabel.setText(f"{v} {QCoreApplication.translate('Nugget', u'Seconds', None)}")
+        )
+
+        self.lockScreenAutoLockSeparator = QFrame(self.springboardOptionsPageContent)
+        self.lockScreenAutoLockSeparator.setObjectName(u"lockScreenAutoLockSeparator")
+        self.lockScreenAutoLockSeparator.setStyleSheet(u"QFrame {\n"
+"	color: #414141;\n"
+"}")
+        self.lockScreenAutoLockSeparator.setFrameShadow(QFrame.Plain)
+        self.lockScreenAutoLockSeparator.setFrameShape(QFrame.Shape.HLine)
+
+        self._2.addWidget(self.lockScreenAutoLockSeparator)
+
         self.disableLockRespringChk = QCheckBox(self.springboardOptionsPageContent)
         self.disableLockRespringChk.setObjectName(u"disableLockRespringChk")
 
@@ -4763,6 +4792,8 @@ class Ui_Nugget(object):
         self.disableDimmingChk.setText(QCoreApplication.translate("Nugget", u"Disable Screen Dimming While Charging", None))
         self.disableBatteryAlertsChk.setText(QCoreApplication.translate("Nugget", u"Disable Low Battery Alerts", None))
         self.hideACPowerChk.setText(QCoreApplication.translate("Nugget", u"Hide AC Power on Lock Screen", None))
+        self.lockScreenAutoLockLabel.setText(QCoreApplication.translate("Nugget", u"Auto‑Lock (Lock Screen)", None))
+        
 #if QT_CONFIG(tooltip)
         self.disableCrumbChk.setToolTip(QCoreApplication.translate("Nugget", u"Removes '< PreviousAppName' glyph in Status Bar when being forwarded to another app.", None))
 #endif // QT_CONFIG(tooltip)

--- a/tweaks/tweak_loader.py
+++ b/tweaks/tweak_loader.py
@@ -227,6 +227,11 @@ def load_springboard():
         "AirplaySupport": BasicPlistTweak(
             FileLocation.springboard,
             "SBExtendedDisplayOverrideSupportForAirPlayAndDontFileRadars"
+        ),
+        "SBMinimumLockscreenIdleTime": BasicPlistTweak(
+            FileLocation.springboard,
+            key="SBMinimumLockscreenIdleTime",
+            value=5
         )
     }
     tweaks.update(additional_tweaks)


### PR DESCRIPTION
### Adds support for the `SBMinimumLockscreenIdleTime` SpringBoard key via a new slider in the UI.

#### Behavior:
Allows users to set the minimum number of seconds before the device auto-locks the screen.

#### Changes:
- **UI:** Added `"Auto‑Lock (Lock Screen)"` label and slider (5–100 seconds range)  
- **Logic:** Sets the `SBMinimumLockscreenIdleTime` key in `com.apple.springboard.plist`

#### Tested on:
iOS 18.5