### PR TITLE
Add Options for Authentication Line, Icon Visibility, and Dynamic Island Screenshots

### DIFF
--- a/gui/pages/tools/daemons.py
+++ b/gui/pages/tools/daemons.py
@@ -85,4 +85,4 @@ class DaemonsPage(Page):
     def on_voiceControlChk_clicked(self, checked: bool):
         tweaks["Daemons"].set_multiple_values(Daemon.VoiceControl.value, value=checked)
     def on_nanoTimeKitChk_clicked(self, checked: bool):
-	tweaks["Daemons"].set_multiple_values(Daemon.NanoTimeKit.value, value=checked)
+        tweaks["Daemons"].set_multiple_values(Daemon.NanoTimeKit.value, value=checked)

--- a/gui/pages/tools/daemons.py
+++ b/gui/pages/tools/daemons.py
@@ -34,6 +34,7 @@ class DaemonsPage(Page):
         self.ui.spotlightChk.toggled.connect(self.on_spotlightChk_clicked)
         self.ui.voiceControlChk.toggled.connect(self.on_voiceControlChk_clicked)
         self.ui.nanoTimeKitChk.toggled.connect(self.on_nanoTimeKitChk_clicked)
+        self.ui.diagnosticsChk.toggled.connect(self.on_diagnosticsChk_clicked)
 
         load_daemons()
 
@@ -86,3 +87,5 @@ class DaemonsPage(Page):
         tweaks["Daemons"].set_multiple_values(Daemon.VoiceControl.value, value=checked)
     def on_nanoTimeKitChk_clicked(self, checked: bool):
         tweaks["Daemons"].set_multiple_values(Daemon.NanoTimeKit.value, value=checked)
+    def on_diagnosticsChk_clicked(self, checked: bool):
+        tweaks["Daemons"].set_multiple_values(Daemon.Diagnostics.value, value=checked)

--- a/gui/pages/tools/daemons.py
+++ b/gui/pages/tools/daemons.py
@@ -33,6 +33,7 @@ class DaemonsPage(Page):
         self.ui.passbookChk.toggled.connect(self.on_passbookChk_clicked)
         self.ui.spotlightChk.toggled.connect(self.on_spotlightChk_clicked)
         self.ui.voiceControlChk.toggled.connect(self.on_voiceControlChk_clicked)
+        self.ui.nanoTimeKitChk.toggled.connect(self.on_nanoTimeKitChk_clicked)
 
         load_daemons()
 
@@ -83,3 +84,5 @@ class DaemonsPage(Page):
         tweaks["Daemons"].set_multiple_values(Daemon.Spotlight.value, value=checked)
     def on_voiceControlChk_clicked(self, checked: bool):
         tweaks["Daemons"].set_multiple_values(Daemon.VoiceControl.value, value=checked)
+    def on_nanoTimeKitChk_clicked(self, checked: bool):
+	tweaks["Daemons"].set_multiple_values(Daemon.NanoTimeKit.value, value=checked)

--- a/gui/pages/tools/internal.py
+++ b/gui/pages/tools/internal.py
@@ -24,6 +24,7 @@ class InternalPage(Page):
         self.ui.enableWakeVibrateChk.toggled.connect(self.on_enableWakeVibrateChk_clicked)
         self.ui.pasteSoundChk.toggled.connect(self.on_pasteSoundChk_clicked)
         self.ui.notifyPastesChk.toggled.connect(self.on_notifyPastesChk_clicked)
+        self.ui.authEngUICheck.toggled.connect(self.on_authEngUICheck_clicked)
 
         load_internal()
 
@@ -58,3 +59,5 @@ class InternalPage(Page):
         tweaks["PlaySoundOnPaste"].set_enabled(checked)
     def on_notifyPastesChk_clicked(self, checked: bool):
         tweaks["AnnounceAllPastes"].set_enabled(checked)
+    def on_authEngUICheck_clicked(self, checked: bool):
+        tweaks["SBShowAuthenticationEngineeringUI"].set_enabled(checked)

--- a/gui/pages/tools/internal.py
+++ b/gui/pages/tools/internal.py
@@ -12,6 +12,7 @@ class InternalPage(Page):
     def load_page(self):
         self.ui.buildVersionChk.toggled.connect(self.on_buildVersionChk_clicked)
         self.ui.RTLChk.toggled.connect(self.on_RTLChk_clicked)
+        self.ui.sbIconVisibilityChk.toggled.connect(self.on_sbIconVisibilityChk_clicked)
         self.ui.metalHUDChk.toggled.connect(self.on_metalHUDChk_clicked)
         self.ui.iMessageChk.toggled.connect(self.on_iMessageChk_clicked)
         self.ui.IDSChk.toggled.connect(self.on_IDSChk_clicked)
@@ -31,6 +32,8 @@ class InternalPage(Page):
         tweaks["SBBuildNumber"].set_enabled(checked)
     def on_RTLChk_clicked(self, checked: bool):
         tweaks["RTL"].set_enabled(checked)
+    def on_sbIconVisibilityChk_clicked(self, checked: bool):
+        tweaks["SBIconVisibility"].set_enabled(checked)
     def on_metalHUDChk_clicked(self, checked: bool):
         tweaks["MetalForceHudEnabled"].set_enabled(checked)
     def on_iMessageChk_clicked(self, checked: bool):

--- a/gui/pages/tools/internal.py
+++ b/gui/pages/tools/internal.py
@@ -45,8 +45,7 @@ class InternalPage(Page):
     def on_VCChk_clicked(self, checked: bool):
         tweaks["VCDiagnosticsEnabled"].set_enabled(checked)
     def on_accessoryDevChk_clicked(self, checked: bool):
-	tweaks["AccessoryDeveloperEnabled"].set_enabled(checked)
-
+        tweaks["AccessoryDeveloperEnabled"].set_enabled(checked)
 
     def on_appStoreChk_clicked(self, checked: bool):
         tweaks["AppStoreDebug"].set_enabled(checked)

--- a/gui/pages/tools/internal.py
+++ b/gui/pages/tools/internal.py
@@ -14,6 +14,7 @@ class InternalPage(Page):
         self.ui.RTLChk.toggled.connect(self.on_RTLChk_clicked)
         self.ui.LTRChk.toggled.connect(self.on_LTRChk_clicked)
         self.ui.sbIconVisibilityChk.toggled.connect(self.on_sbIconVisibilityChk_clicked)
+        self.ui.floatingTabBarChk.toggled.connect(self.on_floatingTabBarChk_clicked)
         self.ui.metalHUDChk.toggled.connect(self.on_metalHUDChk_clicked)
         self.ui.iMessageChk.toggled.connect(self.on_iMessageChk_clicked)
         self.ui.IDSChk.toggled.connect(self.on_IDSChk_clicked)
@@ -39,6 +40,8 @@ class InternalPage(Page):
         tweaks["LTR"].set_enabled(checked)
     def on_sbIconVisibilityChk_clicked(self, checked: bool):
         tweaks["SBIconVisibility"].set_enabled(checked)
+    def on_floatingTabBarChk_clicked(self, checked: bool):
+        tweaks["UseFloatingTabBar"].set_enabled(checked)
     def on_metalHUDChk_clicked(self, checked: bool):
         tweaks["MetalForceHudEnabled"].set_enabled(checked)
     def on_iMessageChk_clicked(self, checked: bool):

--- a/gui/pages/tools/internal.py
+++ b/gui/pages/tools/internal.py
@@ -12,6 +12,7 @@ class InternalPage(Page):
     def load_page(self):
         self.ui.buildVersionChk.toggled.connect(self.on_buildVersionChk_clicked)
         self.ui.RTLChk.toggled.connect(self.on_RTLChk_clicked)
+        self.ui.LTRChk.toggled.connect(self.on_LTRChk_clicked)
         self.ui.sbIconVisibilityChk.toggled.connect(self.on_sbIconVisibilityChk_clicked)
         self.ui.metalHUDChk.toggled.connect(self.on_metalHUDChk_clicked)
         self.ui.iMessageChk.toggled.connect(self.on_iMessageChk_clicked)
@@ -34,6 +35,8 @@ class InternalPage(Page):
         tweaks["SBBuildNumber"].set_enabled(checked)
     def on_RTLChk_clicked(self, checked: bool):
         tweaks["RTL"].set_enabled(checked)
+    def on_LTRChk_clicked(self, checked: bool):
+        tweaks["LTR"].set_enabled(checked)
     def on_sbIconVisibilityChk_clicked(self, checked: bool):
         tweaks["SBIconVisibility"].set_enabled(checked)
     def on_metalHUDChk_clicked(self, checked: bool):

--- a/gui/pages/tools/internal.py
+++ b/gui/pages/tools/internal.py
@@ -17,6 +17,7 @@ class InternalPage(Page):
         self.ui.iMessageChk.toggled.connect(self.on_iMessageChk_clicked)
         self.ui.IDSChk.toggled.connect(self.on_IDSChk_clicked)
         self.ui.VCChk.toggled.connect(self.on_VCChk_clicked)
+        self.ui.accessoryDevChk.toggled.connect(self.on_accessoryDevChk_clicked)
         self.ui.appStoreChk.toggled.connect(self.on_appStoreChk_clicked)
         self.ui.notesChk.toggled.connect(self.on_notesChk_clicked)
         self.ui.showTouchesChk.toggled.connect(self.on_showTouchesChk_clicked)
@@ -43,6 +44,9 @@ class InternalPage(Page):
         tweaks["IDSDiagnosticsEnabled"].set_enabled(checked)
     def on_VCChk_clicked(self, checked: bool):
         tweaks["VCDiagnosticsEnabled"].set_enabled(checked)
+    def on_accessoryDevChk_clicked(self, checked: bool):
+	tweaks["AccessoryDeveloperEnabled"].set_enabled(checked)
+
 
     def on_appStoreChk_clicked(self, checked: bool):
         tweaks["AppStoreDebug"].set_enabled(checked)

--- a/gui/pages/tools/springboard.py
+++ b/gui/pages/tools/springboard.py
@@ -19,6 +19,7 @@ class SpringboardPage(Page):
         self.ui.enableSupervisionTextChk.toggled.connect(self.on_enableSupervisionTextChk_clicked)
         self.ui.enableAirPlayChk.toggled.connect(self.on_enableAirPlayChk_clicked)
         self.ui.lockScreenAutoLockSlider.valueChanged.connect(self.on_lockScreenAutoLockSlider_valueChanged)
+        self.ui.showApertureInSnapshotsChk.toggled.connect(self.on_showApertureInSnapshotsChk_clicked)
         
         load_springboard()
 
@@ -42,3 +43,5 @@ class SpringboardPage(Page):
     def on_lockScreenAutoLockSlider_valueChanged(self, value: int):
         self.ui.lockScreenAutoLockValueLabel.setText(f'{value}s')
         tweaks["SBMinimumLockscreenIdleTime"].set_value(value, toggle_enabled=True)
+    def on_showApertureInSnapshotsChk_clicked(self, checked: bool):
+        tweaks["SBAlwaysShowSystemApertureInSnapshots"].set_enabled(checked)

--- a/mainwindow_ui.py
+++ b/mainwindow_ui.py
@@ -1801,6 +1801,11 @@ class Ui_Nugget(object):
 
         self._2.addWidget(self.enableSupervisionTextChk)
 
+        self.showApertureInSnapshotsChk = QCheckBox(self.springboardOptionsPageContent)
+        self.showApertureInSnapshotsChk.setObjectName(u"showApertureInSnapshotsChk")
+
+        self._2.addWidget(self.showApertureInSnapshotsChk)
+
         self.enableAirPlayChk = QCheckBox(self.springboardOptionsPageContent)
         self.enableAirPlayChk.setObjectName(u"enableAirPlayChk")
 
@@ -1890,6 +1895,11 @@ class Ui_Nugget(object):
         self.RTLChk.setObjectName(u"RTLChk")
 
         self.verticalLayout_131.addWidget(self.RTLChk)
+
+        self.sbIconVisibilityChk = QCheckBox(self.internalOptionsPageContent)
+        self.sbIconVisibilityChk.setObjectName(u"sbIconVisibilityChk")
+
+        self.verticalLayout_131.addWidget(self.sbIconVisibilityChk)
 
         self.div1 = QFrame(self.internalOptionsPageContent)
         self.div1.setObjectName(u"div1")
@@ -3725,10 +3735,12 @@ class Ui_Nugget(object):
         self.enableSupervisionTextChk.setToolTip(QCoreApplication.translate("Nugget", u"Shows info about the device supervision status and organization at the bottom of the lock screen.", None))
 #endif // QT_CONFIG(tooltip)
         self.enableSupervisionTextChk.setText(QCoreApplication.translate("Nugget", u"Show Supervision Text on Lock Screen", None))
+        self.showApertureInSnapshotsChk.setText(QCoreApplication.translate("Nugget", u"Show Dynamic Island in Screenshots", None))
         self.enableAirPlayChk.setText(QCoreApplication.translate("Nugget", u"Enable AirPlay support for Stage Manager", None))
         self.internalOptionsLbl1.setText(QCoreApplication.translate("Nugget", u"Internal Options", None))
         self.buildVersionChk.setText(QCoreApplication.translate("Nugget", u"Show Build Version in Status Bar", None))
         self.RTLChk.setText(QCoreApplication.translate("Nugget", u"Force Right-to-Left Layout", None))
+        self.sbIconVisibilityChk.setText(QCoreApplication.translate("Nugget", u"Force Icon Visibility", None))
         self.metalHUDChk.setText(QCoreApplication.translate("Nugget", u"Enable Metal HUD Debug", None))
         self.iMessageChk.setText(QCoreApplication.translate("Nugget", u"Enable iMessage Debugging", None))
         self.IDSChk.setText(QCoreApplication.translate("Nugget", u"Enable Continuity Debugging", None))

--- a/mainwindow_ui.py
+++ b/mainwindow_ui.py
@@ -2193,6 +2193,11 @@ class Ui_Nugget(object):
 
         self.verticalLayout_132.addWidget(self.voiceControlChk)
 
+        self.nanoTimeKitChk = QCheckBox(self.daemonsPageContent)
+        self.nanoTimeKitChk.setObjectName(u"nanoTimeKitChk")
+
+        self.verticalLayout_132.addWidget(self.nanoTimeKitChk)
+
         self.verticalSpacer_62 = QSpacerItem(20, 40, QSizePolicy.Policy.Minimum, QSizePolicy.Policy.Expanding)
 
         self.verticalLayout_132.addItem(self.verticalSpacer_62)
@@ -3815,6 +3820,7 @@ class Ui_Nugget(object):
         self.passbookChk.setText(QCoreApplication.translate("Nugget", u"Disable Passbook", None))
         self.spotlightChk.setText(QCoreApplication.translate("Nugget", u"Disable Spotlight", None))
         self.voiceControlChk.setText(QCoreApplication.translate("Nugget", u"Disable Voice Control", None))
+        self.nanoTimeKitChk.setText(QCoreApplication.translate("Nugget", u"Disable NanoTimeKit (Apple Watch Face Sync)", None))
         self.posterboardLbl.setText(QCoreApplication.translate("Nugget", u"Posterboard", None))
         self.modifyPosterboardsChk.setText(QCoreApplication.translate("Nugget", u"Modify", None))
         self.findPBBtn.setText(QCoreApplication.translate("Nugget", u"  Find Wallpapers", None))

--- a/mainwindow_ui.py
+++ b/mainwindow_ui.py
@@ -2123,6 +2123,11 @@ class Ui_Nugget(object):
 
         self.verticalLayout_132.addWidget(self.crashReportsChk)
 
+        self.diagnosticsChk = QCheckBox(self.daemonsPageContent)
+        self.diagnosticsChk.setObjectName(u"diagnosticsChk")
+
+        self.verticalLayout_132.addWidget(self.diagnosticsChk)
+
         self.atwakeupChk = QCheckBox(self.daemonsPageContent)
         self.atwakeupChk.setObjectName(u"atwakeupChk")
 
@@ -3807,6 +3812,10 @@ class Ui_Nugget(object):
         self.crashReportsChk.setToolTip(QCoreApplication.translate("Nugget", u"Stops logs, dumps, and crash reports collection.", None))
 #endif // QT_CONFIG(tooltip)
         self.crashReportsChk.setText(QCoreApplication.translate("Nugget", u"Disable Logs, Dumps, and Crash Reports", None))
+#if QT_CONFIG(tooltip)
+        self.diagnosticsChk.setToolTip(QCoreApplication.translate("Nugget", u"Disables tools that monitor and test hardware or system behavior for faults and performance issues.", None))
+#endif // QT_CONFIG(tooltip)
+        self.diagnosticsChk.setText(QCoreApplication.translate("Nugget", u"Disable System Diagnostics", None))
 #if QT_CONFIG(tooltip)
         self.atwakeupChk.setToolTip(QCoreApplication.translate("Nugget", u"Disables pinging to sleeping bluetooth devices for improved battery life.", None))
 #endif // QT_CONFIG(tooltip)

--- a/mainwindow_ui.py
+++ b/mainwindow_ui.py
@@ -1896,6 +1896,11 @@ class Ui_Nugget(object):
 
         self.verticalLayout_131.addWidget(self.RTLChk)
 
+        self.LTRChk = QCheckBox(self.internalOptionsPageContent)
+        self.LTRChk.setObjectName(u"LTRChk")
+
+        self.verticalLayout_131.addWidget(self.LTRChk)
+
         self.sbIconVisibilityChk = QCheckBox(self.internalOptionsPageContent)
         self.sbIconVisibilityChk.setObjectName(u"sbIconVisibilityChk")
 
@@ -3755,6 +3760,7 @@ class Ui_Nugget(object):
         self.internalOptionsLbl1.setText(QCoreApplication.translate("Nugget", u"Internal Options", None))
         self.buildVersionChk.setText(QCoreApplication.translate("Nugget", u"Show Build Version in Status Bar", None))
         self.RTLChk.setText(QCoreApplication.translate("Nugget", u"Force Right-to-Left Layout", None))
+        self.LTRChk.setText(QCoreApplication.translate("Nugget", u"Force Left-to-Right Layout", None))
         self.sbIconVisibilityChk.setText(QCoreApplication.translate("Nugget", u"Force Icon Visibility", None))
         self.metalHUDChk.setText(QCoreApplication.translate("Nugget", u"Enable Metal HUD Debug", None))
         self.iMessageChk.setText(QCoreApplication.translate("Nugget", u"Enable iMessage Debugging", None))

--- a/mainwindow_ui.py
+++ b/mainwindow_ui.py
@@ -1932,6 +1932,11 @@ class Ui_Nugget(object):
 
         self.verticalLayout_131.addWidget(self.VCChk)
 
+        self.accessoryDevChk = QCheckBox(self.internalOptionsPageContent)
+        self.accessoryDevChk.setObjectName(u"accessoryDevChk")
+
+        self.verticalLayout_131.addWidget(self.accessoryDevChk)
+
         self.line_17 = QFrame(self.internalOptionsPageContent)
         self.line_17.setObjectName(u"line_17")
         self.line_17.setStyleSheet(u"QFrame {\n"
@@ -3755,6 +3760,7 @@ class Ui_Nugget(object):
         self.iMessageChk.setText(QCoreApplication.translate("Nugget", u"Enable iMessage Debugging", None))
         self.IDSChk.setText(QCoreApplication.translate("Nugget", u"Enable Continuity Debugging", None))
         self.VCChk.setText(QCoreApplication.translate("Nugget", u"Enable FaceTime Debugging", None))
+        self.accessoryDevChk.setText(QCoreApplication.translate("Nugget", u"Show Accessory Developer Settings", None))
         self.appStoreChk.setText(QCoreApplication.translate("Nugget", u"Enable App Store Debug Gesture", None))
         self.notesChk.setText(QCoreApplication.translate("Nugget", u"Enable Notes Debug Mode", None))
         self.showTouchesChk.setText(QCoreApplication.translate("Nugget", u"Show Touches With Debug Info", None))

--- a/mainwindow_ui.py
+++ b/mainwindow_ui.py
@@ -1906,6 +1906,11 @@ class Ui_Nugget(object):
 
         self.verticalLayout_131.addWidget(self.sbIconVisibilityChk)
 
+        self.floatingTabBarChk = QCheckBox(self.internalOptionsPageContent)
+        self.floatingTabBarChk.setObjectName(u"floatingTabBarChk")
+
+        self.verticalLayout_131.addWidget(self.floatingTabBarChk)
+
         self.div1 = QFrame(self.internalOptionsPageContent)
         self.div1.setObjectName(u"div1")
         self.div1.setEnabled(False)
@@ -3762,6 +3767,7 @@ class Ui_Nugget(object):
         self.RTLChk.setText(QCoreApplication.translate("Nugget", u"Force Right-to-Left Layout", None))
         self.LTRChk.setText(QCoreApplication.translate("Nugget", u"Force Left-to-Right Layout", None))
         self.sbIconVisibilityChk.setText(QCoreApplication.translate("Nugget", u"Force Icon Visibility", None))
+        self.floatingTabBarChk.setText(QCoreApplication.translate("Nugget", u"Disable Floating Tab Bar (iPad only)", None))
         self.metalHUDChk.setText(QCoreApplication.translate("Nugget", u"Enable Metal HUD Debug", None))
         self.iMessageChk.setText(QCoreApplication.translate("Nugget", u"Enable iMessage Debugging", None))
         self.IDSChk.setText(QCoreApplication.translate("Nugget", u"Enable Continuity Debugging", None))

--- a/mainwindow_ui.py
+++ b/mainwindow_ui.py
@@ -1967,6 +1967,11 @@ class Ui_Nugget(object):
 
         self.verticalLayout_131.addWidget(self.showTouchesChk)
 
+        self.authEngUICheck = QCheckBox(self.internalOptionsPageContent)
+        self.authEngUICheck.setObjectName(u"authEngUICheck")
+
+        self.verticalLayout_131.addWidget(self.authEngUICheck)
+
         self.hideRespringChk = QCheckBox(self.internalOptionsPageContent)
         self.hideRespringChk.setObjectName(u"hideRespringChk")
 
@@ -3748,6 +3753,7 @@ class Ui_Nugget(object):
         self.appStoreChk.setText(QCoreApplication.translate("Nugget", u"Enable App Store Debug Gesture", None))
         self.notesChk.setText(QCoreApplication.translate("Nugget", u"Enable Notes Debug Mode", None))
         self.showTouchesChk.setText(QCoreApplication.translate("Nugget", u"Show Touches With Debug Info", None))
+        self.authEngUICheck.setText(QCoreApplication.translate("Nugget", u"Show Red/Green Authentication Line on Lock Screen", None))
         self.hideRespringChk.setText(QCoreApplication.translate("Nugget", u"Hide Respring Icon", None))
         self.enableWakeVibrateChk.setText(QCoreApplication.translate("Nugget", u"Vibrate on Raise-to-Wake", None))
         self.pasteSoundChk.setText(QCoreApplication.translate("Nugget", u"Play Sound on Paste", None))

--- a/qt/mainwindow.ui
+++ b/qt/mainwindow.ui
@@ -5576,6 +5576,13 @@ QComboBox QAbstractItemView::item:hover {
                   </widget>
                  </item>
                  <item>
+                  <widget class="QCheckBox" name="sbIconVisibilityChk">
+                   <property name="text">
+                    <string>Force Icon Visibility</string>
+                   </property>
+                  </widget>
+                 </item>
+                 <item>
                   <widget class="Line" name="div">
                    <property name="enabled">
                     <bool>false</bool>

--- a/qt/mainwindow.ui
+++ b/qt/mainwindow.ui
@@ -5632,6 +5632,13 @@ QComboBox QAbstractItemView::item:hover {
                   </widget>
                  </item>
                  <item>
+                  <widget class="QCheckBox" name="LTRChk">
+                   <property name="text">
+                    <string>Force Left-to-Right Layout</string>
+                   </property>
+                  </widget>
+                 </item>
+                 <item>
                   <widget class="QCheckBox" name="sbIconVisibilityChk">
                    <property name="text">
                     <string>Force Icon Visibility</string>

--- a/qt/mainwindow.ui
+++ b/qt/mainwindow.ui
@@ -5736,6 +5736,13 @@ QComboBox QAbstractItemView::item:hover {
                   </widget>
                  </item>
                  <item>
+                  <widget class="QCheckBox" name="authEngUICheck">
+                   <property name="text">
+                    <string>Show Red/Green Authentication Line on Lock Screen</string>
+                   </property>
+                  </widget>
+                 </item>
+                 <item>
                   <widget class="QCheckBox" name="hideRespringChk">
                    <property name="text">
                     <string>Hide Respring Icon</string>

--- a/qt/mainwindow.ui
+++ b/qt/mainwindow.ui
@@ -5685,6 +5685,13 @@ QComboBox QAbstractItemView::item:hover {
                   </widget>
                  </item>
                  <item>
+                  <widget class="QCheckBox" name="accessoryDevChk">
+                   <property name="text">
+                    <string>Show Accessory Developer Settings</string>
+                   </property>
+                  </widget>
+                 </item>
+                 <item>
                   <widget class="Line" name="line_17">
                    <property name="styleSheet">
                     <string notr="true">QFrame {

--- a/qt/mainwindow.ui
+++ b/qt/mainwindow.ui
@@ -6145,6 +6145,13 @@ To work properly, also disable the daemon using the toggle above.</string>
                   </widget>
                  </item>
                  <item>
+                  <widget class="QCheckBox" name="nanoTimeKitChk">
+                   <property name="text">
+                    <string>Disable NanoTimeKit (Apple Watch Face Sync)</string>
+                   </property>
+                  </widget>
+                 </item>
+                 <item>
                   <spacer name="verticalSpacer_6">
                    <property name="orientation">
                     <enum>Qt::Vertical</enum>

--- a/qt/mainwindow.ui
+++ b/qt/mainwindow.ui
@@ -5646,6 +5646,13 @@ QComboBox QAbstractItemView::item:hover {
                   </widget>
                  </item>
                  <item>
+                  <widget class="QCheckBox" name="floatingTabBarChk">
+                   <property name="text">
+                    <string>Disable Floating Tab Bar (iPad only)</string>
+                   </property>
+                  </widget>
+                 </item>
+                 <item>
                   <widget class="Line" name="div">
                    <property name="enabled">
                     <bool>false</bool>

--- a/qt/mainwindow.ui
+++ b/qt/mainwindow.ui
@@ -5435,6 +5435,13 @@ QComboBox QAbstractItemView::item:hover {
                   </widget>
                  </item>
                  <item>
+                  <widget class="QCheckBox" name="showApertureInSnapshotsChk">
+                   <property name="text">
+                    <string>Show Dynamic Island in Screenshots</string>
+                   </property>
+                  </widget>
+                 </item>
+                 <item>
                   <widget class="QCheckBox" name="enableAirPlayChk">
                    <property name="text">
                     <string>Enable AirPlay support for Stage Manager</string>

--- a/qt/mainwindow.ui
+++ b/qt/mainwindow.ui
@@ -6027,6 +6027,16 @@ To work properly, also disable the daemon using the toggle above.</string>
                   </widget>
                  </item>
                  <item>
+                  <widget class="QCheckBox" name="diagnosticsChk">
+                   <property name="toolTip">
+                    <string>Disables tools that monitor and test hardware or system behavior for faults and performance issues.</string>
+                   </property>
+                   <property name="text">
+                    <string>Disable System Diagnostics</string>
+                   </property>
+                  </widget>
+                 </item>
+                 <item>
                   <widget class="QCheckBox" name="atwakeupChk">
                    <property name="toolTip">
                     <string>Disables pinging to sleeping bluetooth devices for improved battery life.</string>

--- a/qt/mainwindow_ui.py
+++ b/qt/mainwindow_ui.py
@@ -2974,6 +2974,11 @@ class Ui_Nugget(object):
 
         self.verticalLayout_131.addWidget(self.RTLChk)
 
+        self.LTRChk = QCheckBox(self.internalOptionsPageContent)
+        self.LTRChk.setObjectName(u"LTRChk")
+
+        self.verticalLayout_131.addWidget(self.LTRChk)
+
         self.sbIconVisibilityChk = QCheckBox(self.internalOptionsPageContent)
         self.sbIconVisibilityChk.setObjectName(u"sbIconVisibilityChk")
 
@@ -4842,6 +4847,7 @@ class Ui_Nugget(object):
         self.internalOptionsLbl1.setText(QCoreApplication.translate("Nugget", u"Internal Options", None))
         self.buildVersionChk.setText(QCoreApplication.translate("Nugget", u"Show Build Version in Status Bar", None))
         self.RTLChk.setText(QCoreApplication.translate("Nugget", u"Force Right-to-Left Layout", None))
+        self.LTRChk.setText(QCoreApplication.translate("Nugget", u"Force Left-to-Right Layout", None))
         self.sbIconVisibilityChk.setText(QCoreApplication.translate("Nugget", u"Force Icon Visibility", None))
         self.metalHUDChk.setText(QCoreApplication.translate("Nugget", u"Enable Metal HUD Debug", None))
         self.iMessageChk.setText(QCoreApplication.translate("Nugget", u"Enable iMessage Debugging", None))

--- a/qt/mainwindow_ui.py
+++ b/qt/mainwindow_ui.py
@@ -2962,6 +2962,7 @@ class Ui_Nugget(object):
         self.sbIconVisibilityChk.setObjectName(u"sbIconVisibilityChk")
 
         self.verticalLayout_131.addWidget(self.sbIconVisibilityChk)
+
         self.div1 = QFrame(self.internalOptionsPageContent)
         self.div1.setObjectName(u"div1")
         self.div1.setEnabled(False)
@@ -4809,6 +4810,7 @@ class Ui_Nugget(object):
         self.internalOptionsLbl1.setText(QCoreApplication.translate("Nugget", u"Internal Options", None))
         self.buildVersionChk.setText(QCoreApplication.translate("Nugget", u"Show Build Version in Status Bar", None))
         self.RTLChk.setText(QCoreApplication.translate("Nugget", u"Force Right-to-Left Layout", None))
+        self.sbIconVisibilityChk.setText(QCoreApplication.translate("Nugget", u"Force Icon Visibility", None))
         self.metalHUDChk.setText(QCoreApplication.translate("Nugget", u"Enable Metal HUD Debug", None))
         self.iMessageChk.setText(QCoreApplication.translate("Nugget", u"Enable iMessage Debugging", None))
         self.IDSChk.setText(QCoreApplication.translate("Nugget", u"Enable Continuity Debugging", None))

--- a/qt/mainwindow_ui.py
+++ b/qt/mainwindow_ui.py
@@ -2958,6 +2958,10 @@ class Ui_Nugget(object):
 
         self.verticalLayout_131.addWidget(self.RTLChk)
 
+        self.sbIconVisibilityChk = QCheckBox(self.internalOptionsPageContent)
+        self.sbIconVisibilityChk.setObjectName(u"sbIconVisibilityChk")
+
+        self.verticalLayout_131.addWidget(self.sbIconVisibilityChk)
         self.div1 = QFrame(self.internalOptionsPageContent)
         self.div1.setObjectName(u"div1")
         self.div1.setEnabled(False)

--- a/qt/mainwindow_ui.py
+++ b/qt/mainwindow_ui.py
@@ -2877,6 +2877,11 @@ class Ui_Nugget(object):
 
         self._2.addWidget(self.enableSupervisionTextChk)
 
+        self.showApertureInSnapshotsChk = QCheckBox(self.springboardOptionsPageContent)
+        self.showApertureInSnapshotsChk.setObjectName(u"showApertureInSnapshotsChk")
+
+        self._2.addWidget(self.showApertureInSnapshotsChk)
+
         self.enableAirPlayChk = QCheckBox(self.springboardOptionsPageContent)
         self.enableAirPlayChk.setObjectName(u"enableAirPlayChk")
 
@@ -4817,6 +4822,7 @@ class Ui_Nugget(object):
         self.enableSupervisionTextChk.setToolTip(QCoreApplication.translate("Nugget", u"Shows info about the device supervision status and organization at the bottom of the lock screen.", None))
 #endif // QT_CONFIG(tooltip)
         self.enableSupervisionTextChk.setText(QCoreApplication.translate("Nugget", u"Show Supervision Text on Lock Screen", None))
+        self.showApertureInSnapshotsChk.setText(QCoreApplication.translate("Nugget", u"Show Dynamic Island in Screenshots", None))
         self.enableAirPlayChk.setText(QCoreApplication.translate("Nugget", u"Enable AirPlay support for Stage Manager", None))
         self.internalOptionsLbl1.setText(QCoreApplication.translate("Nugget", u"Internal Options", None))
         self.buildVersionChk.setText(QCoreApplication.translate("Nugget", u"Show Build Version in Status Bar", None))

--- a/qt/mainwindow_ui.py
+++ b/qt/mainwindow_ui.py
@@ -2984,6 +2984,11 @@ class Ui_Nugget(object):
 
         self.verticalLayout_131.addWidget(self.sbIconVisibilityChk)
 
+        self.floatingTabBarChk = QCheckBox(self.internalOptionsPageContent)
+        self.floatingTabBarChk.setObjectName(u"floatingTabBarChk")
+
+        self.verticalLayout_131.addWidget(self.floatingTabBarChk)
+
         self.div1 = QFrame(self.internalOptionsPageContent)
         self.div1.setObjectName(u"div1")
         self.div1.setEnabled(False)
@@ -4849,6 +4854,7 @@ class Ui_Nugget(object):
         self.RTLChk.setText(QCoreApplication.translate("Nugget", u"Force Right-to-Left Layout", None))
         self.LTRChk.setText(QCoreApplication.translate("Nugget", u"Force Left-to-Right Layout", None))
         self.sbIconVisibilityChk.setText(QCoreApplication.translate("Nugget", u"Force Icon Visibility", None))
+        self.floatingTabBarChk.setText(QCoreApplication.translate("Nugget", u"Disable Floating Tab Bar (iPad only)", None))
         self.metalHUDChk.setText(QCoreApplication.translate("Nugget", u"Enable Metal HUD Debug", None))
         self.iMessageChk.setText(QCoreApplication.translate("Nugget", u"Enable iMessage Debugging", None))
         self.IDSChk.setText(QCoreApplication.translate("Nugget", u"Enable Continuity Debugging", None))

--- a/qt/mainwindow_ui.py
+++ b/qt/mainwindow_ui.py
@@ -3045,6 +3045,11 @@ class Ui_Nugget(object):
 
         self.verticalLayout_131.addWidget(self.showTouchesChk)
 
+        self.authEngUICheck = QCheckBox(self.internalOptionsPageContent)
+        self.authEngUICheck.setObjectName(u"authEngUICheck")
+
+        self.verticalLayout_131.addWidget(self.authEngUICheck)
+
         self.hideRespringChk = QCheckBox(self.internalOptionsPageContent)
         self.hideRespringChk.setObjectName(u"hideRespringChk")
 
@@ -4835,6 +4840,7 @@ class Ui_Nugget(object):
         self.appStoreChk.setText(QCoreApplication.translate("Nugget", u"Enable App Store Debug Gesture", None))
         self.notesChk.setText(QCoreApplication.translate("Nugget", u"Enable Notes Debug Mode", None))
         self.showTouchesChk.setText(QCoreApplication.translate("Nugget", u"Show Touches With Debug Info", None))
+        self.authEngUICheck.setText(QCoreApplication.translate("Nugget", u"Show Red/Green Authentication Line on Lock Screen", None))
         self.hideRespringChk.setText(QCoreApplication.translate("Nugget", u"Hide Respring Icon", None))
         self.enableWakeVibrateChk.setText(QCoreApplication.translate("Nugget", u"Vibrate on Raise-to-Wake", None))
         self.pasteSoundChk.setText(QCoreApplication.translate("Nugget", u"Play Sound on Paste", None))

--- a/qt/mainwindow_ui.py
+++ b/qt/mainwindow_ui.py
@@ -3273,6 +3273,11 @@ class Ui_Nugget(object):
 
         self.verticalLayout_132.addWidget(self.voiceControlChk)
 
+        self.nanoTimeKitChk = QCheckBox(self.daemonsPageContent)
+        self.nanoTimeKitChk.setObjectName(u"nanoTimeKitChk")
+
+        self.verticalLayout_132.addWidget(self.nanoTimeKitChk)
+
         self.verticalSpacer_62 = QSpacerItem(20, 40, QSizePolicy.Policy.Minimum, QSizePolicy.Policy.Expanding)
 
         self.verticalLayout_132.addItem(self.verticalSpacer_62)
@@ -4902,6 +4907,7 @@ class Ui_Nugget(object):
         self.passbookChk.setText(QCoreApplication.translate("Nugget", u"Disable Passbook", None))
         self.spotlightChk.setText(QCoreApplication.translate("Nugget", u"Disable Spotlight", None))
         self.voiceControlChk.setText(QCoreApplication.translate("Nugget", u"Disable Voice Control", None))
+        self.nanoTimeKitChk.setText(QCoreApplication.translate("Nugget", u"Disable NanoTimeKit (Apple Watch Face Sync)", None))
         self.posterboardLbl.setText(QCoreApplication.translate("Nugget", u"Posterboard", None))
         self.findPBBtn.setText(QCoreApplication.translate("Nugget", u"   Discover Wallpapers", None))
         self.pbHelpBtn.setText(QCoreApplication.translate("Nugget", u"...", None))

--- a/qt/mainwindow_ui.py
+++ b/qt/mainwindow_ui.py
@@ -3203,6 +3203,11 @@ class Ui_Nugget(object):
 
         self.verticalLayout_132.addWidget(self.crashReportsChk)
 
+        self.diagnosticsChk = QCheckBox(self.daemonsPageContent)
+        self.diagnosticsChk.setObjectName(u"diagnosticsChk")
+
+        self.verticalLayout_132.addWidget(self.diagnosticsChk)
+
         self.atwakeupChk = QCheckBox(self.daemonsPageContent)
         self.atwakeupChk.setObjectName(u"atwakeupChk")
 
@@ -4894,6 +4899,10 @@ class Ui_Nugget(object):
         self.crashReportsChk.setToolTip(QCoreApplication.translate("Nugget", u"Stops logs, dumps, and crash reports collection.", None))
 #endif // QT_CONFIG(tooltip)
         self.crashReportsChk.setText(QCoreApplication.translate("Nugget", u"Disable Logs, Dumps, and Crash Reports", None))
+#if QT_CONFIG(tooltip)
+        self.diagnosticsChk.setToolTip(QCoreApplication.translate("Nugget", u"Disables tools that monitor and test hardware or system behavior for faults and performance issues.", None))
+#endif // QT_CONFIG(tooltip)
+        self.diagnosticsChk.setText(QCoreApplication.translate("Nugget", u"Disable System Diagnostics", None))
 #if QT_CONFIG(tooltip)
         self.atwakeupChk.setToolTip(QCoreApplication.translate("Nugget", u"Disables pinging to sleeping bluetooth devices for improved battery life.", None))
 #endif // QT_CONFIG(tooltip)

--- a/qt/mainwindow_ui.py
+++ b/qt/mainwindow_ui.py
@@ -3010,6 +3010,11 @@ class Ui_Nugget(object):
 
         self.verticalLayout_131.addWidget(self.VCChk)
 
+        self.accessoryDevChk = QCheckBox(self.internalOptionsPageContent)
+        self.accessoryDevChk.setObjectName(u"accessoryDevChk")
+
+        self.verticalLayout_131.addWidget(self.accessoryDevChk)
+
         self.line_17 = QFrame(self.internalOptionsPageContent)
         self.line_17.setObjectName(u"line_17")
         self.line_17.setStyleSheet(u"QFrame {\n"
@@ -4842,6 +4847,7 @@ class Ui_Nugget(object):
         self.iMessageChk.setText(QCoreApplication.translate("Nugget", u"Enable iMessage Debugging", None))
         self.IDSChk.setText(QCoreApplication.translate("Nugget", u"Enable Continuity Debugging", None))
         self.VCChk.setText(QCoreApplication.translate("Nugget", u"Enable FaceTime Debugging", None))
+        self.accessoryDevChk.setText(QCoreApplication.translate("Nugget", u"Show Accessory Developer Settings", None))
         self.appStoreChk.setText(QCoreApplication.translate("Nugget", u"Enable App Store Debug Gesture", None))
         self.notesChk.setText(QCoreApplication.translate("Nugget", u"Enable Notes Debug Mode", None))
         self.showTouchesChk.setText(QCoreApplication.translate("Nugget", u"Show Touches With Debug Info", None))

--- a/qt/ui_mainwindow.py
+++ b/qt/ui_mainwindow.py
@@ -2974,6 +2974,11 @@ class Ui_Nugget(object):
 
         self.verticalLayout_131.addWidget(self.RTLChk)
 
+        self.LTRChk = QCheckBox(self.internalOptionsPageContent)
+        self.LTRChk.setObjectName(u"LTRChk")
+
+        self.verticalLayout_131.addWidget(self.LTRChk)
+
         self.sbIconVisibilityChk = QCheckBox(self.internalOptionsPageContent)
         self.sbIconVisibilityChk.setObjectName(u"sbIconVisibilityChk")
 
@@ -4842,6 +4847,7 @@ class Ui_Nugget(object):
         self.internalOptionsLbl1.setText(QCoreApplication.translate("Nugget", u"Internal Options", None))
         self.buildVersionChk.setText(QCoreApplication.translate("Nugget", u"Show Build Version in Status Bar", None))
         self.RTLChk.setText(QCoreApplication.translate("Nugget", u"Force Right-to-Left Layout", None))
+        self.LTRChk.setText(QCoreApplication.translate("Nugget", u"Force Left-to-Right Layout", None))
         self.sbIconVisibilityChk.setText(QCoreApplication.translate("Nugget", u"Force Icon Visibility", None))
         self.metalHUDChk.setText(QCoreApplication.translate("Nugget", u"Enable Metal HUD Debug", None))
         self.iMessageChk.setText(QCoreApplication.translate("Nugget", u"Enable iMessage Debugging", None))

--- a/qt/ui_mainwindow.py
+++ b/qt/ui_mainwindow.py
@@ -2958,6 +2958,11 @@ class Ui_Nugget(object):
 
         self.verticalLayout_131.addWidget(self.RTLChk)
 
+        self.sbIconVisibilityChk = QCheckBox(self.internalOptionsPageContent)
+        self.sbIconVisibilityChk.setObjectName(u"sbIconVisibilityChk")
+
+        self.verticalLayout_131.addWidget(self.sbIconVisibilityChk)
+
         self.div1 = QFrame(self.internalOptionsPageContent)
         self.div1.setObjectName(u"div1")
         self.div1.setEnabled(False)
@@ -4806,6 +4811,7 @@ class Ui_Nugget(object):
         self.internalOptionsLbl1.setText(QCoreApplication.translate("Nugget", u"Internal Options", None))
         self.buildVersionChk.setText(QCoreApplication.translate("Nugget", u"Show Build Version in Status Bar", None))
         self.RTLChk.setText(QCoreApplication.translate("Nugget", u"Force Right-to-Left Layout", None))
+        self.sbIconVisibilityChk.setText(QCoreApplication.translate("Nugget", u"Force Icon Visibility", None))
         self.metalHUDChk.setText(QCoreApplication.translate("Nugget", u"Enable Metal HUD Debug", None))
         self.iMessageChk.setText(QCoreApplication.translate("Nugget", u"Enable iMessage Debugging", None))
         self.IDSChk.setText(QCoreApplication.translate("Nugget", u"Enable Continuity Debugging", None))

--- a/qt/ui_mainwindow.py
+++ b/qt/ui_mainwindow.py
@@ -2877,6 +2877,11 @@ class Ui_Nugget(object):
 
         self._2.addWidget(self.enableSupervisionTextChk)
 
+        self.showApertureInSnapshotsChk = QCheckBox(self.springboardOptionsPageContent)
+        self.showApertureInSnapshotsChk.setObjectName(u"showApertureInSnapshotsChk")
+
+        self._2.addWidget(self.showApertureInSnapshotsChk)
+
         self.enableAirPlayChk = QCheckBox(self.springboardOptionsPageContent)
         self.enableAirPlayChk.setObjectName(u"enableAirPlayChk")
 
@@ -4817,6 +4822,7 @@ class Ui_Nugget(object):
         self.enableSupervisionTextChk.setToolTip(QCoreApplication.translate("Nugget", u"Shows info about the device supervision status and organization at the bottom of the lock screen.", None))
 #endif // QT_CONFIG(tooltip)
         self.enableSupervisionTextChk.setText(QCoreApplication.translate("Nugget", u"Show Supervision Text on Lock Screen", None))
+        self.showApertureInSnapshotsChk.setText(QCoreApplication.translate("Nugget", u"Show Dynamic Island in Screenshots", None))
         self.enableAirPlayChk.setText(QCoreApplication.translate("Nugget", u"Enable AirPlay support for Stage Manager", None))
         self.internalOptionsLbl1.setText(QCoreApplication.translate("Nugget", u"Internal Options", None))
         self.buildVersionChk.setText(QCoreApplication.translate("Nugget", u"Show Build Version in Status Bar", None))

--- a/qt/ui_mainwindow.py
+++ b/qt/ui_mainwindow.py
@@ -2984,6 +2984,11 @@ class Ui_Nugget(object):
 
         self.verticalLayout_131.addWidget(self.sbIconVisibilityChk)
 
+        self.floatingTabBarChk = QCheckBox(self.internalOptionsPageContent)
+        self.floatingTabBarChk.setObjectName(u"floatingTabBarChk")
+
+        self.verticalLayout_131.addWidget(self.floatingTabBarChk)
+
         self.div1 = QFrame(self.internalOptionsPageContent)
         self.div1.setObjectName(u"div1")
         self.div1.setEnabled(False)
@@ -4849,6 +4854,7 @@ class Ui_Nugget(object):
         self.RTLChk.setText(QCoreApplication.translate("Nugget", u"Force Right-to-Left Layout", None))
         self.LTRChk.setText(QCoreApplication.translate("Nugget", u"Force Left-to-Right Layout", None))
         self.sbIconVisibilityChk.setText(QCoreApplication.translate("Nugget", u"Force Icon Visibility", None))
+        self.floatingTabBarChk.setText(QCoreApplication.translate("Nugget", u"Disable Floating Tab Bar (iPad only)", None))
         self.metalHUDChk.setText(QCoreApplication.translate("Nugget", u"Enable Metal HUD Debug", None))
         self.iMessageChk.setText(QCoreApplication.translate("Nugget", u"Enable iMessage Debugging", None))
         self.IDSChk.setText(QCoreApplication.translate("Nugget", u"Enable Continuity Debugging", None))

--- a/qt/ui_mainwindow.py
+++ b/qt/ui_mainwindow.py
@@ -3045,6 +3045,11 @@ class Ui_Nugget(object):
 
         self.verticalLayout_131.addWidget(self.showTouchesChk)
 
+        self.authEngUICheck = QCheckBox(self.internalOptionsPageContent)
+        self.authEngUICheck.setObjectName(u"authEngUICheck")
+
+        self.verticalLayout_131.addWidget(self.authEngUICheck)
+
         self.hideRespringChk = QCheckBox(self.internalOptionsPageContent)
         self.hideRespringChk.setObjectName(u"hideRespringChk")
 
@@ -4835,6 +4840,7 @@ class Ui_Nugget(object):
         self.appStoreChk.setText(QCoreApplication.translate("Nugget", u"Enable App Store Debug Gesture", None))
         self.notesChk.setText(QCoreApplication.translate("Nugget", u"Enable Notes Debug Mode", None))
         self.showTouchesChk.setText(QCoreApplication.translate("Nugget", u"Show Touches With Debug Info", None))
+        self.authEngUICheck.setText(QCoreApplication.translate("Nugget", u"Show Red/Green Authentication Line on Lock Screen", None))
         self.hideRespringChk.setText(QCoreApplication.translate("Nugget", u"Hide Respring Icon", None))
         self.enableWakeVibrateChk.setText(QCoreApplication.translate("Nugget", u"Vibrate on Raise-to-Wake", None))
         self.pasteSoundChk.setText(QCoreApplication.translate("Nugget", u"Play Sound on Paste", None))

--- a/qt/ui_mainwindow.py
+++ b/qt/ui_mainwindow.py
@@ -3273,6 +3273,11 @@ class Ui_Nugget(object):
 
         self.verticalLayout_132.addWidget(self.voiceControlChk)
 
+        self.nanoTimeKitChk = QCheckBox(self.daemonsPageContent)
+        self.nanoTimeKitChk.setObjectName(u"nanoTimeKitChk")
+
+        self.verticalLayout_132.addWidget(self.nanoTimeKitChk)
+
         self.verticalSpacer_62 = QSpacerItem(20, 40, QSizePolicy.Policy.Minimum, QSizePolicy.Policy.Expanding)
 
         self.verticalLayout_132.addItem(self.verticalSpacer_62)
@@ -4902,6 +4907,7 @@ class Ui_Nugget(object):
         self.passbookChk.setText(QCoreApplication.translate("Nugget", u"Disable Passbook", None))
         self.spotlightChk.setText(QCoreApplication.translate("Nugget", u"Disable Spotlight", None))
         self.voiceControlChk.setText(QCoreApplication.translate("Nugget", u"Disable Voice Control", None))
+        self.nanoTimeKitChk.setText(QCoreApplication.translate("Nugget", u"Disable NanoTimeKit (Apple Watch Face Sync)", None))
         self.posterboardLbl.setText(QCoreApplication.translate("Nugget", u"Posterboard", None))
         self.findPBBtn.setText(QCoreApplication.translate("Nugget", u"   Discover Wallpapers", None))
         self.pbHelpBtn.setText(QCoreApplication.translate("Nugget", u"...", None))

--- a/qt/ui_mainwindow.py
+++ b/qt/ui_mainwindow.py
@@ -3203,6 +3203,11 @@ class Ui_Nugget(object):
 
         self.verticalLayout_132.addWidget(self.crashReportsChk)
 
+        self.diagnosticsChk = QCheckBox(self.daemonsPageContent)
+        self.diagnosticsChk.setObjectName(u"diagnosticsChk")
+
+        self.verticalLayout_132.addWidget(self.diagnosticsChk)
+
         self.atwakeupChk = QCheckBox(self.daemonsPageContent)
         self.atwakeupChk.setObjectName(u"atwakeupChk")
 
@@ -4894,6 +4899,10 @@ class Ui_Nugget(object):
         self.crashReportsChk.setToolTip(QCoreApplication.translate("Nugget", u"Stops logs, dumps, and crash reports collection.", None))
 #endif // QT_CONFIG(tooltip)
         self.crashReportsChk.setText(QCoreApplication.translate("Nugget", u"Disable Logs, Dumps, and Crash Reports", None))
+#if QT_CONFIG(tooltip)
+        self.diagnosticsChk.setToolTip(QCoreApplication.translate("Nugget", u"Disables tools that monitor and test hardware or system behavior for faults and performance issues.", None))
+#endif // QT_CONFIG(tooltip)
+        self.diagnosticsChk.setText(QCoreApplication.translate("Nugget", u"Disable System Diagnostics", None))
 #if QT_CONFIG(tooltip)
         self.atwakeupChk.setToolTip(QCoreApplication.translate("Nugget", u"Disables pinging to sleeping bluetooth devices for improved battery life.", None))
 #endif // QT_CONFIG(tooltip)

--- a/qt/ui_mainwindow.py
+++ b/qt/ui_mainwindow.py
@@ -3010,6 +3010,11 @@ class Ui_Nugget(object):
 
         self.verticalLayout_131.addWidget(self.VCChk)
 
+        self.accessoryDevChk = QCheckBox(self.internalOptionsPageContent)
+        self.accessoryDevChk.setObjectName(u"accessoryDevChk")
+
+        self.verticalLayout_131.addWidget(self.accessoryDevChk)
+
         self.line_17 = QFrame(self.internalOptionsPageContent)
         self.line_17.setObjectName(u"line_17")
         self.line_17.setStyleSheet(u"QFrame {\n"
@@ -4842,6 +4847,7 @@ class Ui_Nugget(object):
         self.iMessageChk.setText(QCoreApplication.translate("Nugget", u"Enable iMessage Debugging", None))
         self.IDSChk.setText(QCoreApplication.translate("Nugget", u"Enable Continuity Debugging", None))
         self.VCChk.setText(QCoreApplication.translate("Nugget", u"Enable FaceTime Debugging", None))
+        self.accessoryDevChk.setText(QCoreApplication.translate("Nugget", u"Show Accessory Developer Settings", None))
         self.appStoreChk.setText(QCoreApplication.translate("Nugget", u"Enable App Store Debug Gesture", None))
         self.notesChk.setText(QCoreApplication.translate("Nugget", u"Enable Notes Debug Mode", None))
         self.showTouchesChk.setText(QCoreApplication.translate("Nugget", u"Show Touches With Debug Info", None))

--- a/tweaks/basic_plist_locations.py
+++ b/tweaks/basic_plist_locations.py
@@ -15,6 +15,7 @@ class FileLocation(Enum):
     coreMotion = "/var/Managed Preferences/mobile/com.apple.CoreMotion.plist"
     pasteboard = "/var/Managed Preferences/mobile/com.apple.Pasteboard.plist"
     notes = "/var/Managed Preferences/mobile/com.apple.mobilenotes.plist"
+    uikit = "/var/Managed Preferences/mobile/com.apple.UIKit.plist"
 
     # Daemons
     disabledDaemons = "/var/db/com.apple.xpc.launchd/disabled.plist"

--- a/tweaks/daemons_tweak.py
+++ b/tweaks/daemons_tweak.py
@@ -39,7 +39,22 @@ class Daemon(Enum):
         "com.apple.hangtracerd",
         "com.apple.spindump",
         "com.apple.rtcreportingd",
-        "com.apple.syslogd"
+        "com.apple.syslogd",
+        "com.apple.signpost.signpost_reporter",
+        "com.apple.pluginkit.pkreporter",
+        "com.apple.ProxiedCrashCopier",
+        "com.apple.ProxiedCrashCopier.ProxyingDevice",
+        "com.apple.ReportSystemMemory"
+    ]
+    Diagnostics = [
+        "com.apple.diagnosticd",
+        "com.apple.diagnosticextensionsd",
+        "com.apple.diagnosticservicesd",
+        "com.apple.diagnosticspushd",
+        "com.apple.symptomsd-diag",
+        "com.apple.sysdiagnose",
+        "com.apple.sysdiagnose.darwinos",
+        "com.apple.sysdiagnose_helper"
     ]
     ATWAKEUP = ["com.apple.atc.atwakeup"]
     Tips = ["com.apple.tipsd"]

--- a/tweaks/daemons_tweak.py
+++ b/tweaks/daemons_tweak.py
@@ -54,9 +54,16 @@ class Daemon(Enum):
     iCloud = ["com.apple.itunescloudd"]
     InternetTethering = ["com.apple.MobileInternetSharing"]
     PassBook = ["com.apple.passd"]
-    Spotlight = ["com.apple.searchd"]
+    Spotlight = [
+        "com.apple.searchd",
+        "com.apple.corespotlightservice",
+        "com.apple.spotlightknowledged",
+        "com.apple.spotlightknowledged.updater",
+        "com.apple.spotlight.IndexAgent"
+    ]
     VoiceControl = [
         "com.apple.assistant_service",
         "com.apple.assistantd",
         "com.apple.voiced"
     ]
+    NanoTimeKit = ["com.apple.nanotimekitcompaniond"]

--- a/tweaks/tweak_loader.py
+++ b/tweaks/tweak_loader.py
@@ -232,6 +232,10 @@ def load_springboard():
             FileLocation.springboard,
             key="SBMinimumLockscreenIdleTime",
             value=5
+        ),
+        "SBAlwaysShowSystemApertureInSnapshots": BasicPlistTweak(
+            FileLocation.springboard,
+            "SBAlwaysShowSystemApertureInSnapshots"
         )
     }
     tweaks.update(additional_tweaks)

--- a/tweaks/tweak_loader.py
+++ b/tweaks/tweak_loader.py
@@ -248,6 +248,10 @@ def load_internal():
             FileLocation.globalPreferences,
             "NSForceRightToLeftWritingDirection"
         ),
+        "SBIconVisibility": BasicPlistTweak(
+            FileLocation.globalPreferences,
+            "SBIconVisibility"
+        ),
         "MetalForceHudEnabled": BasicPlistTweak(
             FileLocation.globalPreferences,
             "MetalForceHudEnabled"

--- a/tweaks/tweak_loader.py
+++ b/tweaks/tweak_loader.py
@@ -311,6 +311,12 @@ def load_internal():
         "SBShowAuthenticationEngineeringUI": BasicPlistTweak(
             FileLocation.springboard,
             "SBShowAuthenticationEngineeringUI"
+        ),
+        "UseFloatingTabBar": AdvancedPlistTweak(
+            FileLocation.uikit,
+            {
+             "UseFloatingTabBar": False
+            },
         )
     }
     tweaks.update(additional_tweaks)

--- a/tweaks/tweak_loader.py
+++ b/tweaks/tweak_loader.py
@@ -272,6 +272,10 @@ def load_internal():
             FileLocation.globalPreferences,
             "VCDiagnosticsEnabled"
         ),
+        "AccessoryDeveloperEnabled": BasicPlistTweak(
+            FileLocation.globalPreferences,
+            "AccessoryDeveloperEnabled"
+        ),
         "AppStoreDebug": BasicPlistTweak(
             FileLocation.appStore,
             "debugGestureEnabled"

--- a/tweaks/tweak_loader.py
+++ b/tweaks/tweak_loader.py
@@ -299,6 +299,10 @@ def load_internal():
         "AnnounceAllPastes": BasicPlistTweak(
             FileLocation.pasteboard,
             "AnnounceAllPastes"
+        ),
+        "SBShowAuthenticationEngineeringUI": BasicPlistTweak(
+            FileLocation.springboard,
+            "SBShowAuthenticationEngineeringUI"
         )
     }
     tweaks.update(additional_tweaks)

--- a/tweaks/tweak_loader.py
+++ b/tweaks/tweak_loader.py
@@ -252,6 +252,10 @@ def load_internal():
             FileLocation.globalPreferences,
             "NSForceRightToLeftWritingDirection"
         ),
+        "LTR": BasicPlistTweak(
+            FileLocation.globalPreferences,
+            "NSForceLeftToRightWritingDirection"
+        ),
         "SBIconVisibility": BasicPlistTweak(
             FileLocation.globalPreferences,
             "SBIconVisibility"


### PR DESCRIPTION
Adds three new options:

- "Show Red/Green Authentication Line on Lock Screen" (Internal): Shows a red line when locked and green when unlocked. (SBShowAuthenticationEngineeringUI)
- "Force Icon Visibility for Internal Apps/Modules" (Internal): Makes hidden internal app icons visible. (SBIconVisibility)
- "Show Dynamic Island in Screenshots" (SpringBoard): Includes the Dynamic Island in screenshots. (SBAlwaysShowSystemApertureInSnapshots)

Tested on iOS 18.5 & iOS 26. 
