### PR TITLE
Fix device_manager.py so Nugget actually runs

### DIFF
--- a/devicemanagement/device_manager.py
+++ b/devicemanagement/device_manager.py
@@ -694,7 +694,7 @@ class DeviceManager:
             self.update_label = update_label
             self.do_not_unplug = ""
             if self.data_singleton.current_device.connected_via_usb:
-                self.do_not_unplug = f"\n{QCoreApplication.tr("DO NOT UNPLUG")}"
+                self.do_not_unplug = f"\n{QCoreApplication.tr('DO NOT UNPLUG')}"
             update_label(f"{QCoreApplication.tr("Preparing to restore...")}{self.do_not_unplug}")
             restore_files(
                 files=files_to_restore, reboot=self.auto_reboot,


### PR DESCRIPTION
The double double quotes broke the f-string, switching them to single-quotes fixes Nugget.