### PR TITLE
build.yml: use macos-15-intel for x86_64

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -27,7 +27,7 @@ on:
 jobs:
   build-macos-intel:
     if: ${{ github.event.inputs.build_for_macos_intel == 'true' }}
-    runs-on: macos-13
+    runs-on: macos-15-intel
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-python@v4


### PR DESCRIPTION
The macOS 13 runner image will be retired by December 4th, 2025.