### PR TITLE
tweak_classes: handle iphone 16e under get_rdar_mode as mode 2 (fix dynamic island overlapping status bar on iphone 16e)

### DIFF
--- a/tweaks/tweak_classes.py
+++ b/tweaks/tweak_classes.py
@@ -104,7 +104,7 @@ class RdarFixTweak(BasicPlistTweak):
             self.mode = 1
         elif (model == "iPhone13,2" or model == "iPhone13,3" or model == "iPhone13,4"
               or model == "iPhone14,5" or model == "iPhone14,2" or model == "iPhone14,3"
-              or model == "iPhone14,7" or model == "iPhone14,8"):
+              or model == "iPhone14,7" or model == "iPhone14,8" or model == "iPhone17,5"):
             self.mode = 2
         elif (model == "iPhone12,8" or model == "iPhone14,6"):
             self.mode = 3


### PR DESCRIPTION
* 16e has the same resolution as the 14, and same screen, so this will fix all the dynamic island overlapping status bar issues on 16e.

tests: builds fine, res change takes effect and everything looks good