### PR TITLE
fix: replace 21 bare excepts with except Exception

### DIFF
--- a/src/controllers/files_handler.py
+++ b/src/controllers/files_handler.py
@@ -4,5 +4,5 @@ from os import path, getcwd
 def get_bundle_files(name: str):
     try:
         return path.join(sys._MEIPASS, *name.split('/'))
-    except:
+    except Exception:
         return path.join(getcwd(), *name.split('/'))

--- a/src/devicemanagement/device_manager.py
+++ b/src/devicemanagement/device_manager.py
@@ -112,7 +112,7 @@ class DeviceManager:
         # handle errors when failing to get connected devices
         try:
             connected_devices = usbmux.list_devices()
-        except:
+        except Exception:
             sysmsg = QCoreApplication.tr("If you are on Linux, make sure you have usbmuxd and libimobiledevice installed.")
             if os.name == 'nt':
                 sysmsg = QCoreApplication.tr("Make sure you have the \"Apple Devices\" app from the Microsoft Store or iTunes from Apple's website.")
@@ -150,7 +150,7 @@ class DeviceManager:
                             settings.setValue(device.serial + "_cpu", cpu)
                         else:
                             cpu = cpu_type
-                    except:
+                    except Exception:
                         show_alert(ApplyAlertMessage(txt=QCoreApplication.tr("Click \"Show Details\" for the traceback."), detailed_txt=str(traceback.format_exc())))
                     dev = Device(
                             udid=device.serial,
@@ -545,7 +545,7 @@ class DeviceManager:
                     try:
                         new_ld = create_using_usbmux(serial=self.get_current_device_udid(), pair_timeout=180)
                         connected = True
-                    except:
+                    except Exception:
                         pass
                 cleanup_server_folder()
                 if not connected:

--- a/src/gui/main_window.py
+++ b/src/gui/main_window.py
@@ -267,7 +267,7 @@ class MainWindow(QtWidgets.QMainWindow):
                 self.ui.dynamicIslandDrp.removeItem(6)
                 self.ui.dynamicIslandDrp.removeItem(5)
                 self.ui.dynamicIslandDrp.removeItem(4)
-            except:
+            except Exception:
                 pass
             if TweakID.RdarFix in tweaks:
                 self.pages[Page.Gestalt].set_rdar_fix_label()
@@ -437,7 +437,7 @@ class MainWindow(QtWidgets.QMainWindow):
             self.device_manager.pref_manager.skip_setup = skip_setup
             self.device_manager.pref_manager.supervised = supervised
             self.device_manager.pref_manager.organization_name = organization_name
-        except:
+        except Exception:
             pass
     
 

--- a/src/gui/pages/main/settings.py
+++ b/src/gui/pages/main/settings.py
@@ -84,7 +84,7 @@ class SettingsPage(Page):
         # load the saved option
         try:
             idx = self.lang_indexes.index(self.window.translator.get_saved_locale_code())
-        except:
+        except Exception:
             idx = 0
         self.ui.langDrp.setCurrentIndex(idx)
 
@@ -123,7 +123,7 @@ class SettingsPage(Page):
         self.ui.euEnablerPageBtn.setVisible(show_eu)
         try:
             self.ui.resetPBDrp.removeItem(4)
-        except:
+        except Exception:
             pass
         if visible:
             self.ui.resetPBDrp.addItem("PB Extensions")
@@ -213,13 +213,13 @@ class SettingsPage(Page):
         try:
             self.window.device_manager.send_app_hashes_afc(hashes)
             QMessageBox.information(None, QCoreApplication.tr("PosterBoard App Hash"), QCoreApplication.tr("Your hash has been transferred to the Pocket Poster app.\n\nOpen up its settings and tap \"Detect\"."))
-        except:
+        except Exception:
             # fall back to copy and paste
             copytxt = QCoreApplication.tr("Copy it and paste it")
             try:
                 import pyperclip
                 pyperclip.copy(hashes["com.apple.PosterBoard"])
                 copytxt = QCoreApplication.tr("It has been copied. Paste it")
-            except:
+            except Exception:
                 print("pyperclip not found, not copying to clipboard")
             QMessageBox.information(None, QCoreApplication.tr("PosterBoard App Hash"), QCoreApplication.tr("Your hash is:\n{0}\n\n{1} into the Nugget app where it says \"App Hash\".").format(hashes["com.apple.PosterBoard"], copytxt))

--- a/src/gui/pages/reset_dialog.py
+++ b/src/gui/pages/reset_dialog.py
@@ -38,7 +38,7 @@ class ResetDialog(QDialog):
         else:
             try:
                 self.selected_pages.remove(page)
-            except:
+            except Exception:
                 print("Page not found in list, ignoring error.")
 
     def accept(self):

--- a/src/gui/pages/tools/gestalt.py
+++ b/src/gui/pages/tools/gestalt.py
@@ -55,7 +55,7 @@ class GestaltPage(Page):
         for i in range(1, self.ui.spoofedModelDrp.count()):
             try:
                 self.ui.spoofedModelDrp.removeItem(1)
-            except:
+            except Exception:
                 pass
         # indexes 1-7 for iPhones, 8-(len(values) - 1) for iPads
         # TODO: Make this get fetched from the gui on app startup

--- a/src/gui/pages/tools/risky.py
+++ b/src/gui/pages/tools/risky.py
@@ -41,7 +41,7 @@ class RiskyPage(Page):
             val = int(txt)
             tweaks[TweakID.CustomResolution].value["canvas_height"] = val
             self.ui.resHeightWarningLbl.hide()
-        except:
+        except Exception:
             self.ui.resHeightWarningLbl.show()
     def on_resWidthTxt_textEdited(self, txt: str):
         if txt == "":
@@ -53,5 +53,5 @@ class RiskyPage(Page):
             val = int(txt)
             tweaks[TweakID.CustomResolution].value["canvas_width"] = val
             self.ui.resWidthWarningLbl.hide()
-        except:
+        except Exception:
             self.ui.resWidthWarningLbl.show()

--- a/src/restore/bookrestore.py
+++ b/src/restore/bookrestore.py
@@ -145,7 +145,7 @@ def cleanup_server_folder():
     global old_dir
     try:
         shutil.rmtree(server_folder)
-    except:
+    except Exception:
         pass
     server_folder = None
     if old_dir is not None:
@@ -163,7 +163,7 @@ async def create_connection_context(files: list[FileToRestore], service_provider
                 server_folder = create_server_folder()
             _run_async_rsd_connection(available_address["address"], available_address["port"], files, current_device_uuid_callback, progress_callback, transfer_mode, do_full_reboot)
             cleanup_server_folder()
-        except:
+        except Exception:
             cleanup_server_folder()
             raise
     else:
@@ -213,7 +213,7 @@ def remove_db_files(db_path):
         if os.path.exists(fpath):
             try:
                 os.remove(fpath)
-            except:
+            except Exception:
                 pass
 
 def close_dl_connection():
@@ -404,7 +404,7 @@ def apply_bookrestore_files(files: list[FileToRestore], lockdown_client: Lockdow
                     f'netsh advfirewall firewall delete rule name="{firewall_rule_name}"',
                     shell=True, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL
                 )
-            except:
+            except Exception:
                 pass
 
     procs = OsTraceService(lockdown=lockdown_client).get_pid_list().get("Payload")

--- a/src/tweaks/passcode_theme_tweak.py
+++ b/src/tweaks/passcode_theme_tweak.py
@@ -46,7 +46,7 @@ class PasscodeThemeTweak(Tweak):
                         self.current_size = 2
                     else:
                         self.current_size = 0
-        except:
+        except Exception:
             pass
         finally:
             self.value = final_path

--- a/src/tweaks/status_bar/status_setter.py
+++ b/src/tweaks/status_bar/status_setter.py
@@ -176,7 +176,7 @@ class Setter:
             file_list = "Unable to list files"
             try:
                 file_list = os.listdir(base_path)
-            except:
+            except Exception:
                 pass
             raise NuggetException(f"Failed to run status bar process.\nPath used: {base_path}\nFiles in path: {file_list}\nError: {e}")
             
@@ -187,6 +187,6 @@ class Setter:
             os.remove(tmpin)
             os.remove(tmpout)
             os.rmdir(tmpdir)
-        except:
+        except Exception:
             pass
         return contents


### PR DESCRIPTION
Replace 21 bare `except:` with `except Exception:` across 10 files. Bare `except:` catches `KeyboardInterrupt` and `SystemExit`, masking real errors.