### PR TITLE
Fix macOS ARM build for Apple Silicon

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -59,20 +59,36 @@ jobs:
 
   build-macos-arm:
     if: ${{ github.event.inputs.build_for_macos_arm == 'true' }}
-    runs-on: macos-latest
+    runs-on: macos-15
     steps:
       - uses: actions/checkout@v3
+
       - uses: actions/setup-python@v4
         with:
-          python-version: '3.11'
+          python-version: '3.10'
 
-      - name: Install dependencies
+      - name: Install OpenSSL
         run: |
-          python3 -m pip install -U pip
+          brew update
+          brew install openssl@3 pkg-config
+
+      - name: Create venv and install requirements
+        run: |
+          python3 -m venv .env
+          source .env/bin/activate
+          python -m pip install -U pip setuptools wheel
+
+          OPENSSL_PREFIX="$(brew --prefix openssl@3)"
+          export CPPFLAGS="-I$OPENSSL_PREFIX/include"
+          export LDFLAGS="-L$OPENSSL_PREFIX/lib"
+          export PKG_CONFIG_PATH="$OPENSSL_PREFIX/lib/pkgconfig"
+
           pip install --no-binary sslpsk_pmd3 -r requirements.txt
 
       - name: Build macOS (ARM)
-        run: python3 compile.py
+        run: |
+          source .env/bin/activate
+          python3 compile.py
 
       - name: Zip Nugget.app (ARM)
         run: |


### PR DESCRIPTION
Add OpenSSL setup and environment flags for macOS ARM builds so sslpsk_pmd3 can compile correctly in GitHub Actions.