### PR TITLE
Add option to disable FollowUp daemon

### DIFF
--- a/src/devicemanagement/device_manager.py
+++ b/src/devicemanagement/device_manager.py
@@ -308,6 +308,14 @@ class DeviceManager:
         QMessageBox.information(None, QCoreApplication.tr("Pairing Reset"), QCoreApplication.tr("Your device's pairing was successfully reset. Refresh the device list before applying."))
         
 
+    def add_rebuild_sb_application_state_db(self, files_to_restore: list[FileToRestore]):
+        if self.pref_manager.rebuild_sb_application_state_db:
+            files_to_restore.append(FileToRestore(
+                contents=b"",
+                restore_path="Library/FrontBoard/applicationState.db",
+                domain="HomeDomain"
+            ))
+
     def add_skip_setup(self, files_to_restore: list[FileToRestore], restoring_domains: bool):
         # TODO: Probably should move this to its own file
         if self.pref_manager.skip_setup and (not self.get_current_device_supported() or restoring_domains):
@@ -671,6 +679,7 @@ class DeviceManager:
                     path=FileLocation.featureflags.value,
                     files_to_restore=files_to_restore, use_bookrestore=True
                 )
+            self.add_rebuild_sb_application_state_db(files_to_restore)
             self.add_skip_setup(files_to_restore, uses_domains and (not use_bookrestore or self.pref_manager.bookrestore_apply_mode == BookRestoreApplyMethod.Restore))
             if gestalt_data != None and use_bookrestore:
                 self.concat_file(

--- a/src/devicemanagement/preference_manager.py
+++ b/src/devicemanagement/preference_manager.py
@@ -12,6 +12,7 @@ class PreferenceManager:
         self.show_all_spoofable_models = False
         self.disable_tendies_limit = False
         self.auto_refresh_posterboard = True
+        self.rebuild_sb_application_state_db = False
         self.restore_truststore = False
         self.bookrestore_apply_mode = BookRestoreApplyMethod.AFC
         self.bookrestore_transfer_mode = BookRestoreFileTransferMethod.LocalHost

--- a/src/gui/pages/main/settings.py
+++ b/src/gui/pages/main/settings.py
@@ -62,6 +62,7 @@ class SettingsPage(Page):
         self.ui.ignorePBFrameLimitChk.toggled.connect(self.on_ignorePBFrameLimitChk_toggled)
         self.ui.disableTendiesLimitChk.toggled.connect(self.on_disableTendiesLimitChk_toggled)
         self.ui.forcePBRefreshChk.toggled.connect(self.on_forcePBRefreshChk_toggled)
+        self.ui.rebuildSBApplicationStateDBChk.toggled.connect(self.on_rebuildSBApplicationStateDBChk_toggled)
 
         self.ui.brApplyModeDrp.activated.connect(self.on_brApplyModeDrp_activated)
         self.ui.brTransferModeDrp.activated.connect(self.on_brTransferModeDrp_activated)
@@ -155,6 +156,8 @@ class SettingsPage(Page):
     def on_forcePBRefreshChk_toggled(self, checked: bool):
         self.window.device_manager.pref_manager.auto_refresh_posterboard = checked
         self.window.settings.setValue("auto_refresh_posterboard", checked)
+    def on_rebuildSBApplicationStateDBChk_toggled(self, checked: bool):
+        self.window.device_manager.pref_manager.rebuild_sb_application_state_db = checked
     def on_showAllSpoofableChk_toggled(self, checked: bool):
         self.window.device_manager.pref_manager.show_all_spoofable_models = checked
         # save the setting

--- a/src/gui/pages/tools/daemons.py
+++ b/src/gui/pages/tools/daemons.py
@@ -35,6 +35,7 @@ class DaemonsPage(Page):
         self.ui.voiceControlChk.toggled.connect(self.on_voiceControlChk_clicked)
         self.ui.nanoTimeKitChk.toggled.connect(self.on_nanoTimeKitChk_clicked)
         self.ui.diagnosticsChk.toggled.connect(self.on_diagnosticsChk_clicked)
+        self.ui.followUpChk.toggled.connect(self.on_followUpChk_clicked)
 
         load_daemons()
 
@@ -89,3 +90,5 @@ class DaemonsPage(Page):
         tweaks[TweakID.Daemons].set_multiple_values(Daemon.NanoTimeKit.value, value=checked)
     def on_diagnosticsChk_clicked(self, checked: bool):
         tweaks[TweakID.Daemons].set_multiple_values(Daemon.Diagnostics.value, value=checked)
+    def on_followUpChk_clicked(self, checked: bool):
+        tweaks[TweakID.Daemons].set_multiple_values(Daemon.FollowUp.value, value=checked)

--- a/src/qt/mainwindow.ui
+++ b/src/qt/mainwindow.ui
@@ -11317,6 +11317,21 @@ DO NOT unplug your device during restores.</string>
                       </widget>
                      </item>
                      <item>
+                      <widget class="QCheckBox" name="rebuildSBApplicationStateDBChk">
+                       <property name="text">
+                        <string>Rebuild SpringBoard Application State DB</string>
+                       </property>
+                       <property name="toolTip">
+                        <string>Replaces applicationState.db with an empty file, causing SpringBoard to rebuild it.
+
+This is necessary if badges persist on the Settings app after disabling FollowUp.</string>
+                       </property>
+                       <property name="checked">
+                        <bool>false</bool>
+                       </property>
+                      </widget>
+                     </item>
+                     <item>
                       <widget class="QWidget" name="bookrestoreWidget" native="true">
                        <layout class="QVBoxLayout" name="verticalLayout_62">
                         <property name="leftMargin">

--- a/src/qt/mainwindow.ui
+++ b/src/qt/mainwindow.ui
@@ -8499,6 +8499,16 @@ To work properly, also disable the daemon using the toggle above.</string>
                   </widget>
                  </item>
                  <item>
+                  <widget class="QCheckBox" name="followUpChk">
+                   <property name="cursor">
+                    <cursorShape>PointingHandCursor</cursorShape>
+                   </property>
+                   <property name="text">
+                    <string>Disable FollowUp</string>
+                   </property>
+                  </widget>
+                 </item>
+                 <item>
                   <spacer name="verticalSpacer_6">
                    <property name="orientation">
                     <enum>Qt::Vertical</enum>

--- a/src/qt/mainwindow_ui.py
+++ b/src/qt/mainwindow_ui.py
@@ -4460,6 +4460,12 @@ class Ui_Nugget(object):
 
         self.verticalLayout_133.addWidget(self.nanoTimeKitChk)
 
+        self.followUpChk = QCheckBox(self.daemonsPageContent)
+        self.followUpChk.setObjectName(u"followUpChk")
+        self.followUpChk.setCursor(QCursor(Qt.CursorShape.PointingHandCursor))
+
+        self.verticalLayout_133.addWidget(self.followUpChk)
+
         self.verticalSpacer_61 = QSpacerItem(20, 40, QSizePolicy.Policy.Minimum, QSizePolicy.Policy.Expanding)
 
         self.verticalLayout_133.addItem(self.verticalSpacer_61)
@@ -6494,6 +6500,7 @@ class Ui_Nugget(object):
         self.spotlightChk.setText(QCoreApplication.translate("Nugget", u"Disable Spotlight", None))
         self.voiceControlChk.setText(QCoreApplication.translate("Nugget", u"Disable Voice Control", None))
         self.nanoTimeKitChk.setText(QCoreApplication.translate("Nugget", u"Disable NanoTimeKit (Apple Watch Face Sync)", None))
+        self.followUpChk.setText(QCoreApplication.translate("Nugget", u"Disable FollowUp", None))
         self.posterboardLbl.setText(QCoreApplication.translate("Nugget", u"Posterboard", None))
         self.findPBBtn.setText(QCoreApplication.translate("Nugget", u"   Discover Wallpapers", None))
         self.pbHelpBtn.setText(QCoreApplication.translate("Nugget", u"...", None))

--- a/src/qt/mainwindow_ui.py
+++ b/src/qt/mainwindow_ui.py
@@ -3,7 +3,7 @@
 ################################################################################
 ## Form generated from reading UI file 'mainwindow.ui'
 ##
-## Created by: Qt User Interface Compiler version 6.7.3
+## Created by: Qt User Interface Compiler version 6.10.3
 ##
 ## WARNING! All changes made in this file will be lost when recompiling UI file!
 ################################################################################
@@ -5834,6 +5834,12 @@ class Ui_Nugget(object):
 
         self._21.addWidget(self.forcePBRefreshChk)
 
+        self.rebuildSBApplicationStateDBChk = QCheckBox(self.settingsPageContent)
+        self.rebuildSBApplicationStateDBChk.setObjectName(u"rebuildSBApplicationStateDBChk")
+        self.rebuildSBApplicationStateDBChk.setChecked(False)
+
+        self._21.addWidget(self.rebuildSBApplicationStateDBChk)
+
         self.bookrestoreWidget = QWidget(self.settingsPageContent)
         self.bookrestoreWidget.setObjectName(u"bookrestoreWidget")
         self.verticalLayout_621 = QVBoxLayout(self.bookrestoreWidget)
@@ -6613,6 +6619,12 @@ class Ui_Nugget(object):
 #endif // QT_CONFIG(tooltip)
         self.disableTendiesLimitChk.setText(QCoreApplication.translate("Nugget", u"Disable Tendies Limit", None))
         self.forcePBRefreshChk.setText(QCoreApplication.translate("Nugget", u"Force PosterBoard Refresh", None))
+        self.rebuildSBApplicationStateDBChk.setText(QCoreApplication.translate("Nugget", u"Rebuild SpringBoard Application State DB", None))
+#if QT_CONFIG(tooltip)
+        self.rebuildSBApplicationStateDBChk.setToolTip(QCoreApplication.translate("Nugget", u"Replaces applicationState.db with an empty file, causing SpringBoard to rebuild it.\n"
+"\n"
+"This is necessary if badges persist on the Settings app after disabling FollowUp.", None))
+#endif // QT_CONFIG(tooltip)
         self.label_511.setText(QCoreApplication.translate("Nugget", u"BookRestore Apply Method", None))
         self.brApplyModeDrp.setItemText(1, QCoreApplication.translate("Nugget", u"   Restore", None))
 

--- a/src/tweaks/daemons_tweak.py
+++ b/src/tweaks/daemons_tweak.py
@@ -86,3 +86,4 @@ class Daemon(Enum):
         "com.apple.voiced"
     ]
     NanoTimeKit = ["com.apple.nanotimekitcompaniond"]
+    FollowUp = ["com.apple.followupd"]


### PR DESCRIPTION
This pull request adds an option to disable `followupd`, the CoreFollowUp daemon. This framework is responsible for nags such as:

- "Update to iOS 26"
- "Try Apple Music again for 3 Months free."
- "Finish Your Battery Repair"
- "Finish Setting Up Your iPhone"

Shortly after launch, Settings queries CoreFollowUp for "follow-ups" and then displays them under the "Apple Account" section. Disabling `followupd` prevents these from appearing.

Unfortunately, disabling the daemon does not remove the number badge on Settings.

To do this, I added a new option called "Rebuild SpringBoard Application State DB", which replaces `Library/FrontBoard/applicationState.db` with an empty file. SpringBoard will then rebuild the database on the next reboot. I couldn't find an existing mechanism to delete the file entirely. Please advise if there is a better way. Also, let me know if there is a better place to put this in the UI.

I tested this on an iOS 18.7.8 device with a clean install. I do not have any spare devices to test on other iOS versions.